### PR TITLE
Fix instrumentation and retrofit tests

### DIFF
--- a/tw-tasks-executor/src/main/java/com/transferwise/tasks/helpers/MicrometerMeterHelper.java
+++ b/tw-tasks-executor/src/main/java/com/transferwise/tasks/helpers/MicrometerMeterHelper.java
@@ -41,13 +41,13 @@ public class MicrometerMeterHelper implements IMeterHelper {
     @Override
     public void registerTaskProcessingEnd(String bucketId, String taskType) {
         String resolvedBucketId = resolveBucketId(bucketId);
-        meterRegistry.counter(METRIC_PREFIX + "tasks.processingsCount", "bucketId", resolvedBucketId, "taskType", taskType).increment();
+        meterRegistry.counter(METRIC_PREFIX + "tasks.processedCount", "bucketId", resolvedBucketId, "taskType", taskType).increment();
         gauges.get(Triple.of("tasks.ongoingProcessingsCount", resolvedBucketId, taskType)).decrementAndGet();
     }
 
     @Override
     public void registerKafkaCoreMessageProcessing(String topic) {
-        meterRegistry.counter(METRIC_PREFIX + "coreKafka.processedMessagesCount", Tags.of("topic", topic));
+        meterRegistry.counter(METRIC_PREFIX + "coreKafka.processedMessagesCount", Tags.of("topic", topic)).increment();
     }
 
     @Override

--- a/tw-tasks-executor/src/test/groovy/com/transferwise/tasks/testappa/CoreKafkaListenerIntSpec.groovy
+++ b/tw-tasks-executor/src/test/groovy/com/transferwise/tasks/testappa/CoreKafkaListenerIntSpec.groovy
@@ -1,0 +1,92 @@
+package com.transferwise.tasks.testappa
+
+import com.transferwise.tasks.helpers.kafka.messagetotask.CoreKafkaListener
+import com.transferwise.tasks.helpers.kafka.messagetotask.IKafkaMessageHandler
+import com.transferwise.tasks.helpers.kafka.messagetotask.KafkaMessageHandlerRegistry
+import com.transferwise.tasks.impl.tokafka.test.IToKafkaTestHelper
+import com.transferwise.tasks.test.BaseIntSpec
+import io.micrometer.core.instrument.MeterRegistry
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Primary
+import org.springframework.test.context.TestPropertySource
+import spock.util.concurrent.PollingConditions
+
+import java.util.concurrent.atomic.AtomicInteger
+
+import static org.awaitility.Awaitility.await
+
+@TestPropertySource(properties = [
+		"spring.main.allow-bean-definition-overriding=true"
+])
+class CoreKafkaListenerIntSpec extends BaseIntSpec {
+
+	@Autowired
+	private IToKafkaTestHelper toKafkaTestHelper
+
+	@Autowired
+	private KafkaProperties kafkaProperties
+
+	@Autowired
+	private MeterRegistry meterRegistry
+
+	@Autowired
+	private CoreKafkaListener kafkaListener
+
+	private final static TOPIC_NAME = "myTopic"
+
+	def "should track the number of messages consumed per topic"() {
+		given:
+			Thread thread
+			int N = 10
+			Map<String, AtomicInteger> messagesReceivedCounts = [:]
+
+			for (int i = 0; i < N; i++) {
+				String message = "Message" + i
+				messagesReceivedCounts[message] = new AtomicInteger(0)
+				toKafkaTestHelper.sendDirectKafkaMessage(TOPIC_NAME, message)
+			}
+		when:
+			kafkaListener.kafkaDataCenterPrefixes = []
+			thread = new Thread({ kafkaListener.poll([TOPIC_NAME]) as Runnable})
+			thread.start()
+		then:
+			new PollingConditions(timeout: 10, delay: 0.5).eventually {
+				meterRegistry.find("twTasks.coreKafka.processedMessagesCount")
+						.tag("topic", TOPIC_NAME).counter().count() == N
+			}
+		cleanup:
+			thread.interrupt()
+	}
+
+	@TestConfiguration
+	static class ContextConfiguration {
+		@Bean
+		KafkaMessageHandlerRegistry twTasksKafkaMessageHandlerRegistry() {
+			return new KafkaMessageHandlerRegistry()
+		}
+
+		@Bean
+		IKafkaMessageHandler aHandlerForTopicA() {
+			return new IKafkaMessageHandler() {
+
+				@Override
+				List<IKafkaMessageHandler.Topic> getTopics() {
+					Collections.singletonList(new IKafkaMessageHandler.Topic().setAddress(TOPIC_NAME))
+				}
+
+				@Override
+				boolean handles(String topic) {
+					return topic == TOPIC_NAME
+				}
+
+				@Override
+				void handle(ConsumerRecord record) {
+				}
+			}
+		}
+	}
+}

--- a/tw-tasks-executor/src/test/groovy/com/transferwise/tasks/testappa/config/TestContainersInitializer.java
+++ b/tw-tasks-executor/src/test/groovy/com/transferwise/tasks/testappa/config/TestContainersInitializer.java
@@ -21,6 +21,7 @@ import java.io.OutputStream;
 import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -41,7 +42,8 @@ public class TestContainersInitializer implements ApplicationContextInitializer<
             if (container == null) {
                 int kafka1Port = SocketUtils.findAvailableTcpPort();
 
-                Path tempDirectory = Files.createTempDirectory("tw-tasks-tests");
+                Path tempDirectory = Files.createTempDirectory(Paths.get("/tmp"), "tw-tasks-tests");
+
                 PathMatchingResourcePatternResolver resolver = new PathMatchingResourcePatternResolver();
                 org.springframework.core.io.Resource[] resources = resolver.getResources("testcontainers/**/*");
                 for (org.springframework.core.io.Resource resource : resources) {


### PR DESCRIPTION
This PR solves 3 issues:
- task processing counter is reporting twice the expected amount
- test container on Docker for Desktop on Mac OSX is failing due to different mounted paths
- kafka consumed messages metrics per topic were not reported

