### PR TITLE
Change values of sample passwords

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,13 +19,13 @@ references:
       name: mysql1
       command: mysqld --max_allowed_packet=32m --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --log_error_verbosity=1 --log_warnings=1
       environment:
-        MYSQL_ROOT_PASSWORD: Kalamaja123
+        MYSQL_ROOT_PASSWORD: example-password-change-me
         MYSQL_DATABASE: tw-tasks-test
     - image: circleci/postgres:9.6.8-alpine
       name: postgres1
       environment:
         POSTGRES_USER: postgres
-        POSTGRES_PASSWORD: Kalamaja123
+        POSTGRES_PASSWORD: example-password-change-me
     - image: zookeeper:3.5.4-beta
       name: zk-service1
       environment:

--- a/demoapp/docker/docker-compose.yml
+++ b/demoapp/docker/docker-compose.yml
@@ -56,7 +56,7 @@ services:
       - "13306:3306"
     environment:
       MYSQL_DATABASE: demoapp
-      MYSQL_ROOT_PASSWORD: Kalamaja123
+      MYSQL_ROOT_PASSWORD: example-password-change-me
     command: mysqld --max_connections=200 --ssl=0 --innodb_buffer_pool_size=256m --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --transaction-isolation=READ-COMMITTED
   mariadb:
     image: mariadb:10.2.15
@@ -65,14 +65,14 @@ services:
       - "13307:3306"
     environment:
       MYSQL_DATABASE: demoapp
-      MYSQL_ROOT_PASSWORD: Kalamaja123
+      MYSQL_ROOT_PASSWORD: example-password-change-me
     command: mysqld --max_connections=200 --ssl=0 --innodb_buffer_pool_size=256m --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --transaction-isolation=READ-COMMITTED
   postgres:
     image: postgres:9.6.11
     ports:
       - "15432:5432"
     environment:
-      POSTGRES_PASSWORD: Kalamaja123
+      POSTGRES_PASSWORD: example-password-change-me
     volumes:
       - ./postgres//postgre-initdb.d:/docker-entrypoint-initdb.d
     command: -c 'max_connections=200'

--- a/demoapp/src/main/resources/application.yml
+++ b/demoapp/src/main/resources/application.yml
@@ -9,7 +9,7 @@ spring:
   datasource:
     url: jdbc:postgresql://host.local:15432/postgres # TODO: Get rid of host.local
     username: postgres
-    password: Kalamaja123
+    password: example-password-change-me
     tomcat:
       max-active: 30
       max-idle: 30
@@ -123,7 +123,7 @@ spring:
   datasource:
     url: jdbc:mysql://localhost:13306/demoapp?characterEncoding=UTF-8&rewriteBatchedStatements=true&useSSL=false
     username: root
-    password: Kalamaja123
+    password: example-password-change-me
 
 tw-tasks.core:
   db-type: MYSQL

--- a/tw-tasks-executor/src/test/resources/config/application.yml
+++ b/tw-tasks-executor/src/test/resources/config/application.yml
@@ -60,7 +60,7 @@ spring:
   datasource:
     url: jdbc:mysql://${testenv.mysql.host:localhost}:${testenv.mysql.port}/tw-tasks-test?maxAllowedPacket=1073741824&useSSL=false&rewriteBatchStatements=true
     username: root
-    password: Kalamaja123
+    password: example-password-change-me
   kafka:
     client-id: test-mysql
     consumer:
@@ -80,7 +80,7 @@ spring:
   datasource:
     url: jdbc:postgresql://${testenv.postgres.host:localhost}:${testenv.postgres.port}/postgres
     username: postgres
-    password: Kalamaja123
+    password: example-password-change-me
   kafka:
     client-id: test-postgres
     consumer:

--- a/tw-tasks-executor/src/test/resources/testcontainers/compose-test.yml
+++ b/tw-tasks-executor/src/test/resources/testcontainers/compose-test.yml
@@ -47,12 +47,12 @@ services:
     hostname: mysql1
     command: mysqld --max_allowed_packet=32m --innodb_buffer_pool_size=100m --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --log_error_verbosity=1 --log_warnings=1
     environment:
-      MYSQL_ROOT_PASSWORD: Kalamaja123
+      MYSQL_ROOT_PASSWORD: example-password-change-me
       MYSQL_DATABASE: tw-tasks-test
   postgres1:
     image: postgres:10.4
     environment:
-      POSTGRES_PASSWORD: Kalamaja123
+      POSTGRES_PASSWORD: example-password-change-me
 networks:
   default:
     driver: bridge


### PR DESCRIPTION
For example config files, use a value for passwords that makes it clear to readers that the provided
default value is for example purposes only, and needs to be changed in production.

We have received some false-positive [vulnerability reports](https://transferwise.com/responsible-disclosure) where people think they found a production password value. This change should avoid future reports.