### PR TITLE
feat: add retry policy to explicitly specify delays between retries

### DIFF
--- a/tw-tasks-executor/src/main/java/com/transferwise/tasks/handler/FixSecondsRetryPolicy.java
+++ b/tw-tasks-executor/src/main/java/com/transferwise/tasks/handler/FixSecondsRetryPolicy.java
@@ -1,0 +1,53 @@
+package com.transferwise.tasks.handler;
+
+import com.transferwise.common.baseutils.clock.ClockHolder;
+import com.transferwise.tasks.domain.ITask;
+import com.transferwise.tasks.handler.interfaces.ITaskRetryPolicy;
+
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Allows fine-tuning retry policies by explicitly defining the delays between retries.
+ */
+public class FixSecondsRetryPolicy implements ITaskRetryPolicy {
+
+    private final List<Integer> seconds;
+
+    /**
+     * @param seconds list of delays between retries in seconds.
+     */
+    public FixSecondsRetryPolicy(int... seconds) {
+        this.seconds = Arrays.stream(seconds)
+            .peek(x -> {
+                if (x <= 0) {
+                    throw new IllegalArgumentException("Delay in seconds for retrying must be positive!");
+                }
+            })
+            .boxed()
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    public ZonedDateTime getRetryTime(ITask taskForProcessing, Throwable t) {
+        final long triesCount = taskForProcessing.getProcessingTriesCount();
+
+        if (triesCount >= seconds.size()) {
+            return null;
+        }
+
+        long addedTimeSeconds = 0;
+        for (int i = 0; i <= triesCount; i++) {
+            addedTimeSeconds += seconds.get(i);
+        }
+
+        return now().plus(addedTimeSeconds, ChronoUnit.SECONDS);
+    }
+
+    public ZonedDateTime now() {
+        return ZonedDateTime.now(ClockHolder.getClock());
+    }
+}

--- a/tw-tasks-executor/src/test/groovy/com/transferwise/tasks/handler/FixSecondsRetryPolicyTest.groovy
+++ b/tw-tasks-executor/src/test/groovy/com/transferwise/tasks/handler/FixSecondsRetryPolicyTest.groovy
@@ -1,0 +1,43 @@
+package com.transferwise.tasks.handler
+
+import com.transferwise.common.baseutils.clock.ClockHolder
+import com.transferwise.tasks.domain.ITask
+import com.transferwise.tasks.domain.Task
+import spock.lang.Specification
+
+import java.time.ZonedDateTime
+
+class FixSecondsRetryPolicyTest extends Specification {
+
+    def "zero retries"() {
+        given:
+            def policy = new FixSecondsRetryPolicy()
+            ITask task = new Task(processingTriesCount: 0)
+        when:
+            def retime = policy.getRetryTime(task, null)
+        then:
+            retime == null
+    }
+
+    def "first retry, second retry, nth retry"() {
+        given:
+            def policy = Spy(new FixSecondsRetryPolicy(1, 2))
+            def now = ZonedDateTime.now(ClockHolder.getClock())
+            policy.now() >> now
+        when:
+            ITask task = new Task(processingTriesCount: 0)
+            def retime = policy.getRetryTime(task, null)
+        then:
+            retime == now.plusSeconds(1)
+        when:
+            task = new Task(processingTriesCount: 1)
+            retime = policy.getRetryTime(task, null)
+        then:
+            retime == now.plusSeconds(3)
+        when:
+            task = new Task(processingTriesCount: 3)
+            retime = policy.getRetryTime(task, null)
+        then:
+            retime == null
+    }
+}


### PR DESCRIPTION
This `RetryPolicy` implementation allows us to set the delays between retries explicitly.
