### PR TITLE
Document Update - Update topic creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ tw-tasks:
 ```
 
 ##### Create Kafka topic
-(If your server does not support auto topic creation)
+You need to [create kafka topic](https://octopus.tw.ee/kafka/topic/create) according to following naming pattern
 
 `twTasks.MyFancyServiceName.executeTask.default`
 - partitions count should be usually the service nodes count + canaries count.


### PR DESCRIPTION
No service allow to create topic on production so instead of old statements I add octopus create topic link which will be clear for engineers about how to do that.