### PR TITLE
Add ability to use custom kafka config for tw-task library by introducing TwTaskKafkaConfiguration bean

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,18 @@ And one topic for each additional bucket:
 
 Reference application where a configuration can be basically copied from is `demoapp`.
 
+### Custom Kafka Configuration
+`tw-tasks` library can be configured with custom Kafka config by defining `TwTasksKafkaConfiguration` bean in your application:
+```java
+@Bean
+public TwTasksKafkaConfiguration twTaskKafkaConfiguration() {
+    KafkaProperties props = ...;
+    KafkaTemplate<String, String> template = ...;
+
+    return new TwTasksKafkaConfiguration(props, template);
+}
+```
+
 ## Algorithms Used
 Some engineers want to understand how the engine actually works and which algorithms and tricks are used.
 

--- a/tw-tasks-executor/gradle.properties
+++ b/tw-tasks-executor/gradle.properties
@@ -1,3 +1,3 @@
-version=1.2.0
+version=1.1.5
 curator.version=4.2.0
 org.gradle.internal.http.socketTimeout=120000

--- a/tw-tasks-executor/gradle.properties
+++ b/tw-tasks-executor/gradle.properties
@@ -1,3 +1,3 @@
-version=1.1.4
+version=1.2.0
 curator.version=4.2.0
 org.gradle.internal.http.socketTimeout=120000

--- a/tw-tasks-executor/src/main/java/com/transferwise/tasks/TwTasksAutoConfiguration.java
+++ b/tw-tasks-executor/src/main/java/com/transferwise/tasks/TwTasksAutoConfiguration.java
@@ -7,7 +7,7 @@ import com.transferwise.common.gracefulshutdown.GracefulShutdowner;
 import com.transferwise.tasks.buckets.BucketsManager;
 import com.transferwise.tasks.cleaning.TasksCleaner;
 import com.transferwise.tasks.config.IExecutorServicesProvider;
-import com.transferwise.tasks.config.TwTaskKafkaConfiguration;
+import com.transferwise.tasks.config.TwTasksKafkaConfiguration;
 import com.transferwise.tasks.dao.ITaskDao;
 import com.transferwise.tasks.dao.MySqlTaskDao;
 import com.transferwise.tasks.dao.PostgresTaskDao;
@@ -258,8 +258,8 @@ public class TwTasksAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public TwTaskKafkaConfiguration twTaskKafkaConfiguration(KafkaProperties kafkaProperties, KafkaTemplate<String, String> kafkaTemplate) {
-        return new TwTaskKafkaConfiguration(kafkaProperties, kafkaTemplate);
+    public TwTasksKafkaConfiguration twTaskKafkaConfiguration(KafkaProperties kafkaProperties, KafkaTemplate<String, String> kafkaTemplate) {
+        return new TwTasksKafkaConfiguration(kafkaProperties, kafkaTemplate);
     }
 
     public static class TwTasksDataSourceProvider {

--- a/tw-tasks-executor/src/main/java/com/transferwise/tasks/TwTasksAutoConfiguration.java
+++ b/tw-tasks-executor/src/main/java/com/transferwise/tasks/TwTasksAutoConfiguration.java
@@ -7,6 +7,7 @@ import com.transferwise.common.gracefulshutdown.GracefulShutdowner;
 import com.transferwise.tasks.buckets.BucketsManager;
 import com.transferwise.tasks.cleaning.TasksCleaner;
 import com.transferwise.tasks.config.IExecutorServicesProvider;
+import com.transferwise.tasks.config.TwTaskKafkaConfiguration;
 import com.transferwise.tasks.dao.ITaskDao;
 import com.transferwise.tasks.dao.MySqlTaskDao;
 import com.transferwise.tasks.dao.PostgresTaskDao;
@@ -45,6 +46,7 @@ import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -52,6 +54,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.format.datetime.standard.DateTimeFormatterRegistrar;
 import org.springframework.format.support.DefaultFormattingConversionService;
 import org.springframework.format.support.FormattingConversionService;
+import org.springframework.kafka.core.KafkaTemplate;
 
 import javax.sql.DataSource;
 
@@ -253,6 +256,12 @@ public class TwTasksAutoConfiguration {
         return new ClusterWideTasksStateMonitor();
     }
 
+    @Bean
+    @ConditionalOnMissingBean
+    public TwTaskKafkaConfiguration twTaskKafkaConfiguration(KafkaProperties kafkaProperties, KafkaTemplate<String, String> kafkaTemplate) {
+        return new TwTaskKafkaConfiguration(kafkaProperties, kafkaTemplate);
+    }
+
     public static class TwTasksDataSourceProvider {
         private final DataSource dataSource;
 
@@ -264,5 +273,4 @@ public class TwTasksAutoConfiguration {
             return dataSource;
         }
     }
-
 }

--- a/tw-tasks-executor/src/main/java/com/transferwise/tasks/config/TwTaskKafkaConfiguration.java
+++ b/tw-tasks-executor/src/main/java/com/transferwise/tasks/config/TwTaskKafkaConfiguration.java
@@ -4,10 +4,8 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.kafka.core.KafkaTemplate;
-import org.springframework.stereotype.Component;
 
 @Getter
-@Component
 @RequiredArgsConstructor
 public class TwTaskKafkaConfiguration {
 

--- a/tw-tasks-executor/src/main/java/com/transferwise/tasks/config/TwTaskKafkaConfiguration.java
+++ b/tw-tasks-executor/src/main/java/com/transferwise/tasks/config/TwTaskKafkaConfiguration.java
@@ -1,0 +1,16 @@
+package com.transferwise.tasks.config;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Component
+@RequiredArgsConstructor
+public class TwTaskKafkaConfiguration {
+
+    private final KafkaProperties kafkaProperties;
+    private final KafkaTemplate<String, String> kafkaTemplate;
+}

--- a/tw-tasks-executor/src/main/java/com/transferwise/tasks/config/TwTasksKafkaConfiguration.java
+++ b/tw-tasks-executor/src/main/java/com/transferwise/tasks/config/TwTasksKafkaConfiguration.java
@@ -7,7 +7,7 @@ import org.springframework.kafka.core.KafkaTemplate;
 
 @Getter
 @RequiredArgsConstructor
-public class TwTaskKafkaConfiguration {
+public class TwTasksKafkaConfiguration {
 
     private final KafkaProperties kafkaProperties;
     private final KafkaTemplate<String, String> kafkaTemplate;

--- a/tw-tasks-executor/src/main/java/com/transferwise/tasks/helpers/kafka/AdminClientTopicPartitionsManager.java
+++ b/tw-tasks-executor/src/main/java/com/transferwise/tasks/helpers/kafka/AdminClientTopicPartitionsManager.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.transferwise.common.baseutils.ExceptionUtils;
 import com.transferwise.tasks.TasksProperties;
+import com.transferwise.tasks.config.TwTaskKafkaConfiguration;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.DescribeTopicsResult;
@@ -12,7 +13,6 @@ import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 
 import java.util.Arrays;
 import java.util.concurrent.ExecutionException;
@@ -23,14 +23,14 @@ public class AdminClientTopicPartitionsManager implements ITopicPartitionsManage
     private static final int COMMANDS_TIMEOUT_S = 30;
 
     @Autowired
-    private KafkaProperties kafkaProperties;
+    private TwTaskKafkaConfiguration kafkaConfiguration;
     @Autowired
     private TasksProperties tasksProperties;
 
     @Override
     public void setPartitionsCount(String topic, int partitionsCount) {
         ExceptionUtils.doUnchecked(() -> {
-            AdminClient adminClient = AdminClient.create(kafkaProperties.buildAdminProperties());
+            AdminClient adminClient = AdminClient.create(kafkaConfiguration.getKafkaProperties().buildAdminProperties());
             try {
                 DescribeTopicsResult describeTopicsResult = adminClient.describeTopics(Arrays.asList(topic));
                 TopicDescription topicDescription = null;

--- a/tw-tasks-executor/src/main/java/com/transferwise/tasks/helpers/kafka/AdminClientTopicPartitionsManager.java
+++ b/tw-tasks-executor/src/main/java/com/transferwise/tasks/helpers/kafka/AdminClientTopicPartitionsManager.java
@@ -4,7 +4,7 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.transferwise.common.baseutils.ExceptionUtils;
 import com.transferwise.tasks.TasksProperties;
-import com.transferwise.tasks.config.TwTaskKafkaConfiguration;
+import com.transferwise.tasks.config.TwTasksKafkaConfiguration;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.DescribeTopicsResult;
@@ -23,7 +23,7 @@ public class AdminClientTopicPartitionsManager implements ITopicPartitionsManage
     private static final int COMMANDS_TIMEOUT_S = 30;
 
     @Autowired
-    private TwTaskKafkaConfiguration kafkaConfiguration;
+    private TwTasksKafkaConfiguration kafkaConfiguration;
     @Autowired
     private TasksProperties tasksProperties;
 

--- a/tw-tasks-executor/src/main/java/com/transferwise/tasks/helpers/kafka/messagetotask/CoreKafkaListener.java
+++ b/tw-tasks-executor/src/main/java/com/transferwise/tasks/helpers/kafka/messagetotask/CoreKafkaListener.java
@@ -2,6 +2,7 @@ package com.transferwise.tasks.helpers.kafka.messagetotask;
 
 import com.transferwise.common.gracefulshutdown.GracefulShutdownStrategy;
 import com.transferwise.tasks.TasksProperties;
+import com.transferwise.tasks.config.TwTaskKafkaConfiguration;
 import com.transferwise.tasks.helpers.IErrorLoggingThrottler;
 import com.transferwise.tasks.helpers.IMeterHelper;
 import com.transferwise.tasks.helpers.executors.IExecutorsHelper;
@@ -14,7 +15,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 
 import javax.annotation.PostConstruct;
 import java.util.ArrayList;
@@ -26,7 +26,7 @@ import java.util.concurrent.ExecutorService;
 @Slf4j
 public class CoreKafkaListener<T> implements GracefulShutdownStrategy {
     @Autowired
-    private KafkaProperties kafkaProperties;
+    private TwTaskKafkaConfiguration kafkaConfiguration;
     @Autowired
     private IExecutorsHelper executorsHelper;
     @Autowired
@@ -65,7 +65,7 @@ public class CoreKafkaListener<T> implements GracefulShutdownStrategy {
     }
 
     public void poll(List<String> addresses) {
-        Map<String, Object> kafkaConsumerProps = kafkaProperties.buildConsumerProperties();
+        Map<String, Object> kafkaConsumerProps = kafkaConfiguration.getKafkaProperties().buildConsumerProperties();
         kafkaConsumerProps.put(
             ConsumerConfig.CLIENT_ID_CONFIG, kafkaConsumerProps.getOrDefault(ConsumerConfig.CLIENT_ID_CONFIG, "") + ".tw-tasks.core-listener");
 

--- a/tw-tasks-executor/src/main/java/com/transferwise/tasks/helpers/kafka/messagetotask/CoreKafkaListener.java
+++ b/tw-tasks-executor/src/main/java/com/transferwise/tasks/helpers/kafka/messagetotask/CoreKafkaListener.java
@@ -2,7 +2,7 @@ package com.transferwise.tasks.helpers.kafka.messagetotask;
 
 import com.transferwise.common.gracefulshutdown.GracefulShutdownStrategy;
 import com.transferwise.tasks.TasksProperties;
-import com.transferwise.tasks.config.TwTaskKafkaConfiguration;
+import com.transferwise.tasks.config.TwTasksKafkaConfiguration;
 import com.transferwise.tasks.helpers.IErrorLoggingThrottler;
 import com.transferwise.tasks.helpers.IMeterHelper;
 import com.transferwise.tasks.helpers.executors.IExecutorsHelper;
@@ -26,7 +26,7 @@ import java.util.concurrent.ExecutorService;
 @Slf4j
 public class CoreKafkaListener<T> implements GracefulShutdownStrategy {
     @Autowired
-    private TwTaskKafkaConfiguration kafkaConfiguration;
+    private TwTasksKafkaConfiguration kafkaConfiguration;
     @Autowired
     private IExecutorsHelper executorsHelper;
     @Autowired

--- a/tw-tasks-executor/src/main/java/com/transferwise/tasks/impl/tokafka/ToKafkaTaskHandlerConfiguration.java
+++ b/tw-tasks-executor/src/main/java/com/transferwise/tasks/impl/tokafka/ToKafkaTaskHandlerConfiguration.java
@@ -2,7 +2,7 @@ package com.transferwise.tasks.impl.tokafka;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.transferwise.common.baseutils.ExceptionUtils;
-import com.transferwise.tasks.config.TwTaskKafkaConfiguration;
+import com.transferwise.tasks.config.TwTasksKafkaConfiguration;
 import com.transferwise.tasks.handler.ExponentialTaskRetryPolicy;
 import com.transferwise.tasks.handler.SimpleTaskConcurrencyPolicy;
 import com.transferwise.tasks.handler.SimpleTaskProcessingPolicy;
@@ -28,7 +28,7 @@ public class ToKafkaTaskHandlerConfiguration {
     private MeterRegistry meterRegistry;
 
     @Bean
-    public ITaskHandler toKafkaTaskHandler(TwTaskKafkaConfiguration kafkaConfiguration,
+    public ITaskHandler toKafkaTaskHandler(TwTasksKafkaConfiguration kafkaConfiguration,
                                            ObjectMapper objectMapper, ToKafkaProperties toKafkaProperties) {
         return new TaskHandlerAdapter(
             (task) -> ToKafkaTaskType.VALUE.equals(task.getType()),

--- a/tw-tasks-executor/src/main/java/com/transferwise/tasks/impl/tokafka/ToKafkaTaskHandlerConfiguration.java
+++ b/tw-tasks-executor/src/main/java/com/transferwise/tasks/impl/tokafka/ToKafkaTaskHandlerConfiguration.java
@@ -2,6 +2,7 @@ package com.transferwise.tasks.impl.tokafka;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.transferwise.common.baseutils.ExceptionUtils;
+import com.transferwise.tasks.config.TwTaskKafkaConfiguration;
 import com.transferwise.tasks.handler.ExponentialTaskRetryPolicy;
 import com.transferwise.tasks.handler.SimpleTaskConcurrencyPolicy;
 import com.transferwise.tasks.handler.SimpleTaskProcessingPolicy;
@@ -15,7 +16,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.kafka.core.KafkaTemplate;
 
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -23,11 +23,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 @Slf4j
 @Configuration
 public class ToKafkaTaskHandlerConfiguration {
+
     @Autowired(required = false)
     private MeterRegistry meterRegistry;
 
     @Bean
-    public ITaskHandler toKafkaTaskHandler(KafkaTemplate<String, String> kafkaTemplate,
+    public ITaskHandler toKafkaTaskHandler(TwTaskKafkaConfiguration kafkaConfiguration,
                                            ObjectMapper objectMapper, ToKafkaProperties toKafkaProperties) {
         return new TaskHandlerAdapter(
             (task) -> ToKafkaTaskType.VALUE.equals(task.getType()),
@@ -38,7 +39,7 @@ public class ToKafkaTaskHandlerConfiguration {
 
                 String topic = toKafkaMessages.getTopic();
                 for (ToKafkaMessages.Message message : toKafkaMessages.getMessages()) {
-                    kafkaTemplate
+                    kafkaConfiguration.getKafkaTemplate()
                         .send(topic, message.getKey(), message.getMessage())
                         .addCallback(
                             result -> {

--- a/tw-tasks-executor/src/main/java/com/transferwise/tasks/impl/tokafka/test/ToKafkaTestHelper.java
+++ b/tw-tasks-executor/src/main/java/com/transferwise/tasks/impl/tokafka/test/ToKafkaTestHelper.java
@@ -2,6 +2,7 @@ package com.transferwise.tasks.impl.tokafka.test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.transferwise.common.baseutils.ExceptionUtils;
+import com.transferwise.tasks.config.TwTaskKafkaConfiguration;
 import com.transferwise.tasks.domain.Task;
 import com.transferwise.tasks.domain.TaskStatus;
 import com.transferwise.tasks.impl.tokafka.ToKafkaMessages;
@@ -12,7 +13,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.kafka.core.KafkaTemplate;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,7 +23,7 @@ public class ToKafkaTestHelper implements IToKafkaTestHelper {
     @Autowired
     private ITestTasksService testTasksService;
     @Autowired
-    private KafkaTemplate<String, String> kafkaTemplate;
+    private TwTaskKafkaConfiguration kafkaConfiguration;
     @Autowired
     private ObjectMapper objectMapper;
 
@@ -102,7 +102,7 @@ public class ToKafkaTestHelper implements IToKafkaTestHelper {
 
     @Override
     public void sendDirectKafkaMessage(ProducerRecord<String, String> producerRecord) {
-        kafkaTemplate.send(producerRecord)
+        kafkaConfiguration.getKafkaTemplate().send(producerRecord)
             .addCallback(
                 result -> log.debug("Sent and acked Kafka message to topic '{}'.", producerRecord.topic()),
                 exception -> log.error("Sending message to Kafka topic '{}'.", producerRecord.topic(), exception));

--- a/tw-tasks-executor/src/main/java/com/transferwise/tasks/impl/tokafka/test/ToKafkaTestHelper.java
+++ b/tw-tasks-executor/src/main/java/com/transferwise/tasks/impl/tokafka/test/ToKafkaTestHelper.java
@@ -2,7 +2,7 @@ package com.transferwise.tasks.impl.tokafka.test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.transferwise.common.baseutils.ExceptionUtils;
-import com.transferwise.tasks.config.TwTaskKafkaConfiguration;
+import com.transferwise.tasks.config.TwTasksKafkaConfiguration;
 import com.transferwise.tasks.domain.Task;
 import com.transferwise.tasks.domain.TaskStatus;
 import com.transferwise.tasks.impl.tokafka.ToKafkaMessages;
@@ -23,7 +23,7 @@ public class ToKafkaTestHelper implements IToKafkaTestHelper {
     @Autowired
     private ITestTasksService testTasksService;
     @Autowired
-    private TwTaskKafkaConfiguration kafkaConfiguration;
+    private TwTasksKafkaConfiguration kafkaConfiguration;
     @Autowired
     private ObjectMapper objectMapper;
 

--- a/tw-tasks-executor/src/main/java/com/transferwise/tasks/triggering/KafkaTasksExecutionTriggerer.java
+++ b/tw-tasks-executor/src/main/java/com/transferwise/tasks/triggering/KafkaTasksExecutionTriggerer.java
@@ -10,7 +10,7 @@ import com.transferwise.tasks.ITasksService;
 import com.transferwise.tasks.TasksProperties;
 import com.transferwise.tasks.buckets.BucketProperties;
 import com.transferwise.tasks.buckets.IBucketsManager;
-import com.transferwise.tasks.config.TwTaskKafkaConfiguration;
+import com.transferwise.tasks.config.TwTasksKafkaConfiguration;
 import com.transferwise.tasks.dao.ITaskDao;
 import com.transferwise.tasks.domain.BaseTask;
 import com.transferwise.tasks.domain.TaskStatus;
@@ -74,7 +74,7 @@ import static com.transferwise.tasks.helpers.IMeterHelper.METRIC_PREFIX;
 @SuppressWarnings("checkstyle:MultipleStringLiterals")
 public class KafkaTasksExecutionTriggerer implements ITasksExecutionTriggerer, GracefulShutdownStrategy {
     @Autowired
-    private TwTaskKafkaConfiguration kafkaConfiguration;
+    private TwTasksKafkaConfiguration kafkaConfiguration;
     @Autowired
     private ITasksProcessingService tasksProcessingService;
     @Autowired

--- a/tw-tasks-executor/src/main/java/com/transferwise/tasks/triggering/KafkaTasksExecutionTriggerer.java
+++ b/tw-tasks-executor/src/main/java/com/transferwise/tasks/triggering/KafkaTasksExecutionTriggerer.java
@@ -10,6 +10,7 @@ import com.transferwise.tasks.ITasksService;
 import com.transferwise.tasks.TasksProperties;
 import com.transferwise.tasks.buckets.BucketProperties;
 import com.transferwise.tasks.buckets.IBucketsManager;
+import com.transferwise.tasks.config.TwTaskKafkaConfiguration;
 import com.transferwise.tasks.dao.ITaskDao;
 import com.transferwise.tasks.domain.BaseTask;
 import com.transferwise.tasks.domain.TaskStatus;
@@ -42,9 +43,7 @@ import org.apache.kafka.clients.consumer.internals.NoOpConsumerRebalanceListener
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.RetriableException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.context.annotation.Lazy;
-import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -75,13 +74,11 @@ import static com.transferwise.tasks.helpers.IMeterHelper.METRIC_PREFIX;
 @SuppressWarnings("checkstyle:MultipleStringLiterals")
 public class KafkaTasksExecutionTriggerer implements ITasksExecutionTriggerer, GracefulShutdownStrategy {
     @Autowired
-    private KafkaProperties kafkaProperties;
+    private TwTaskKafkaConfiguration kafkaConfiguration;
     @Autowired
     private ITasksProcessingService tasksProcessingService;
     @Autowired
     private ITaskDao taskDao;
-    @Autowired
-    private KafkaTemplate<String, String> kafkaTemplate;
     @Autowired
     private TasksProperties tasksProperties;
     @Autowired
@@ -118,7 +115,7 @@ public class KafkaTasksExecutionTriggerer implements ITasksExecutionTriggerer, G
         executorService = executorsHelper.newCachedExecutor("ktet");
         triggerTopic = "twTasks." + tasksProperties.getGroupId() + ".executeTask";
 
-        kafkaConsumerProps = kafkaProperties.buildConsumerProperties();
+        kafkaConsumerProps = kafkaConfiguration.getKafkaProperties().buildConsumerProperties();
 
         tasksProcessingService.addTaskTriggeringFinishedListener(taskTriggering -> {
             if (taskTriggering.isSameProcessTrigger()) {
@@ -175,7 +172,7 @@ public class KafkaTasksExecutionTriggerer implements ITasksExecutionTriggerer, G
         // TODO: Future improvement: try to also trigger in the same node, if there is room or more specifically if it is idle (for min latency)
         // TODO: Maybe needs another concurrency control for that. E.g. only trigger in node, when conc < 5, even max conc is 10.
 
-        kafkaTemplate.send(getTopic(processingBucketId), UUID.randomUUID().toString(), taskSt).addCallback(
+        kafkaConfiguration.getKafkaTemplate().send(getTopic(processingBucketId), UUID.randomUUID().toString(), taskSt).addCallback(
             result -> {
                 if (log.isDebugEnabled()) {
                     MdcContext.with(() -> {

--- a/tw-tasks-executor/src/test/groovy/com/transferwise/tasks/testappa/ConsistentKafkaConsumerIntSpec.groovy
+++ b/tw-tasks-executor/src/test/groovy/com/transferwise/tasks/testappa/ConsistentKafkaConsumerIntSpec.groovy
@@ -1,11 +1,11 @@
 package com.transferwise.tasks.testappa
 
+import com.transferwise.tasks.config.TwTasksKafkaConfiguration
 import com.transferwise.tasks.helpers.kafka.ConsistentKafkaConsumer
 import com.transferwise.tasks.impl.tokafka.test.IToKafkaTestHelper
 import com.transferwise.tasks.test.BaseIntSpec
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.autoconfigure.kafka.KafkaProperties
 
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -16,7 +16,7 @@ class ConsistentKafkaConsumerIntSpec extends BaseIntSpec {
     @Autowired
     private IToKafkaTestHelper toKafkaTestHelper
     @Autowired
-    private KafkaProperties kafkaProperties
+    private TwTasksKafkaConfiguration kafkaConfiguration
 
     def "all messages will be received once on rebalancing"() {
         given:
@@ -34,7 +34,7 @@ class ConsistentKafkaConsumerIntSpec extends BaseIntSpec {
             boolean shouldFinish = false
 
             ConsistentKafkaConsumer consumer = new ConsistentKafkaConsumer().setKafkaPropertiesSupplier({
-                kafkaProperties.buildConsumerProperties()
+                kafkaConfiguration.getKafkaProperties().buildConsumerProperties()
             })
                 .setTopics([testTopic]).setShouldFinishPredicate({ shouldFinish })
                 .setShouldPollPredicate({ !shouldFinish })

--- a/tw-tasks-executor/src/test/groovy/com/transferwise/tasks/testappa/CoreKafkaListenerIntSpec.groovy
+++ b/tw-tasks-executor/src/test/groovy/com/transferwise/tasks/testappa/CoreKafkaListenerIntSpec.groovy
@@ -5,7 +5,6 @@ import com.transferwise.tasks.impl.tokafka.test.IToKafkaTestHelper
 import com.transferwise.tasks.test.BaseIntSpec
 import io.micrometer.core.instrument.MeterRegistry
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.autoconfigure.kafka.KafkaProperties
 import spock.util.concurrent.PollingConditions
 
 import java.util.concurrent.atomic.AtomicInteger
@@ -16,9 +15,6 @@ class CoreKafkaListenerIntSpec extends BaseIntSpec {
 
     @Autowired
     private IToKafkaTestHelper toKafkaTestHelper
-
-    @Autowired
-    private KafkaProperties kafkaProperties
 
     @Autowired
     private MeterRegistry meterRegistry

--- a/tw-tasks-executor/src/test/groovy/com/transferwise/tasks/testappa/KafkaIntSpec.groovy
+++ b/tw-tasks-executor/src/test/groovy/com/transferwise/tasks/testappa/KafkaIntSpec.groovy
@@ -1,14 +1,13 @@
 package com.transferwise.tasks.testappa
 
 import com.transferwise.common.baseutils.transactionsmanagement.ITransactionsHelper
+import com.transferwise.tasks.config.TwTasksKafkaConfiguration
 import com.transferwise.tasks.helpers.kafka.ConsistentKafkaConsumer
 import com.transferwise.tasks.helpers.kafka.ITopicPartitionsManager
 import com.transferwise.tasks.impl.tokafka.IToKafkaSenderService
 import com.transferwise.tasks.test.BaseIntSpec
 import groovy.util.logging.Slf4j
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.autoconfigure.kafka.KafkaProperties
-import org.springframework.kafka.core.KafkaTemplate
 import spock.lang.Unroll
 
 import java.time.Duration
@@ -20,11 +19,9 @@ import static org.awaitility.Awaitility.await
 @Slf4j
 class KafkaIntSpec extends BaseIntSpec {
     @Autowired
-    private KafkaTemplate<String, String> kafkaTemplate
+    TwTasksKafkaConfiguration kafkaConfiguration
     @Autowired
     private IToKafkaSenderService toKafkaSenderService
-    @Autowired
-    private KafkaProperties kafkaProperties
     @Autowired
     private ITransactionsHelper transactionsHelper
     @Autowired
@@ -54,7 +51,7 @@ class KafkaIntSpec extends BaseIntSpec {
                 .setShouldFinishPredicate({
                     messagesReceivedCount.get() == 1 || System.currentTimeMillis() - start > 30000
                 })
-                .setKafkaPropertiesSupplier({ kafkaProperties.buildConsumerProperties() })
+                .setKafkaPropertiesSupplier({ kafkaConfiguration.getKafkaProperties().buildConsumerProperties() })
                 .setRecordConsumer({ record ->
                     if (record.value() == payload) {
                         messagesReceivedCount.incrementAndGet()
@@ -92,7 +89,7 @@ class KafkaIntSpec extends BaseIntSpec {
                 .setShouldFinishPredicate({
                     messagesMap.find({ k, v -> v.get() != 1 }) == null || System.currentTimeMillis() - start > 30000
                 })
-                .setKafkaPropertiesSupplier({ kafkaProperties.buildConsumerProperties() })
+                .setKafkaPropertiesSupplier({ kafkaConfiguration.getKafkaProperties().buildConsumerProperties() })
                 .setRecordConsumer({ record ->
                     if (record.offset() < iteration * 1000 || record.offset() > (iteration + 1) * 1000 - 1) {
                         throw new IllegalStateException("Unexpected offset detected for iteration " + iteration + ": " + iteration)
@@ -140,7 +137,7 @@ class KafkaIntSpec extends BaseIntSpec {
                 .setShouldFinishPredicate({
                     messagesMap.find({ k, v -> v.get() != 1 }) == null || System.currentTimeMillis() - start > 30000
                 })
-                .setKafkaPropertiesSupplier({ kafkaProperties.buildConsumerProperties() })
+                .setKafkaPropertiesSupplier({ kafkaConfiguration.getKafkaProperties().buildConsumerProperties() })
                 .setRecordConsumer({ record ->
                     if (record.value() != 'Warmup') {
                         messagesMap.get(record.value()).incrementAndGet()
@@ -187,7 +184,7 @@ class KafkaIntSpec extends BaseIntSpec {
                 .setShouldFinishPredicate({
                     messagesMap.find({ k, v -> v.get() != 1 }) == null || System.currentTimeMillis() - start > 30000
                 })
-                .setKafkaPropertiesSupplier({ kafkaProperties.buildConsumerProperties() })
+                .setKafkaPropertiesSupplier({ kafkaConfiguration.kafkaProperties.buildConsumerProperties() })
                 .setRecordConsumer({ record ->
                     if (Math.random() < 0.5) {
                         throw new RuntimeException("Unlucky!")

--- a/tw-tasks-executor/src/test/groovy/com/transferwise/tasks/testappa/config/TestConfiguration.java
+++ b/tw-tasks-executor/src/test/groovy/com/transferwise/tasks/testappa/config/TestConfiguration.java
@@ -2,6 +2,7 @@ package com.transferwise.tasks.testappa.config;
 
 import com.transferwise.tasks.buckets.BucketProperties;
 import com.transferwise.tasks.buckets.IBucketsManager;
+import com.transferwise.tasks.config.TwTasksKafkaConfiguration;
 import com.transferwise.tasks.helpers.kafka.messagetotask.IKafkaMessageHandler;
 import com.transferwise.tasks.impl.tokafka.test.IToKafkaTestHelper;
 import com.transferwise.tasks.impl.tokafka.test.ToKafkaTestHelper;
@@ -14,7 +15,6 @@ import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -32,7 +32,7 @@ public class TestConfiguration {
     private IBucketsManager bucketsManager;
 
     @Autowired
-    private KafkaProperties kafkaProperties;
+    private TwTasksKafkaConfiguration kafkaConfiguration;
 
     @PostConstruct
     @SuppressWarnings("checkstyle:MagicNumber")
@@ -40,7 +40,7 @@ public class TestConfiguration {
         bucketsManager.registerBucketProperties("manualStart", new BucketProperties()
             .setAutoStartProcessing(false));
 
-        AdminClient adminClient = AdminClient.create(kafkaProperties.buildAdminProperties());
+        AdminClient adminClient = AdminClient.create(kafkaConfiguration.getKafkaProperties().buildAdminProperties());
 
         List<NewTopic> newTopics = Arrays.asList(new NewTopic("twTasks.test-mysql.executeTask.manualStart", 1, (short) 1),
             new NewTopic("twTasks.test-mysql.executeTask.default", 1, (short) 1),
@@ -97,4 +97,3 @@ public class TestConfiguration {
         };
     }
 }
-

--- a/tw-tasks-executor/src/test/groovy/com/transferwise/tasks/triggering/KafkaTasksExecutionTriggererSpec.groovy
+++ b/tw-tasks-executor/src/test/groovy/com/transferwise/tasks/triggering/KafkaTasksExecutionTriggererSpec.groovy
@@ -2,7 +2,6 @@ package com.transferwise.tasks.triggering
 
 import com.transferwise.tasks.test.BaseSpec
 import org.apache.kafka.common.TopicPartition
-import spock.lang.Specification
 
 class KafkaTasksExecutionTriggererSpec extends BaseSpec {
 


### PR DESCRIPTION
There is no possibility to configure `tw-task` library with custom kafka configuration right now.
This PR is not bringing any breaking changes. Introduced `TwTaskKafkaConfiguration` bean which can be easily redefined with `@Primary` annotation in spring app to use some custom configuration.