### PR TITLE
Create resilient kafka message handler (PAYINP-304)

### DIFF
--- a/tw-tasks-executor/src/main/java/com/transferwise/tasks/helpers/kafka/messagetotask/CorruptedMessageRecoveryStrategy.java
+++ b/tw-tasks-executor/src/main/java/com/transferwise/tasks/helpers/kafka/messagetotask/CorruptedMessageRecoveryStrategy.java
@@ -1,0 +1,20 @@
+package com.transferwise.tasks.helpers.kafka.messagetotask;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+/**
+ * The strategy used to recover corrupted message (the one that cannot be deserialized)
+ * while processing it with {@link ResilientKafkaMessageHandler}.
+ */
+public interface CorruptedMessageRecoveryStrategy {
+
+    /**
+     * Recovers from infinite processing of the same kafka message.
+     *
+     * @param messageType the type of the message deserialization was failed for
+     * @param record      the record that was failed to be deserialized
+     * @param exception   the exception appeared as deserialization failure
+     * @throws Exception in case recovery is not sufficient and the same record needs to be reprocessed again
+     */
+    void recover(Class<?> messageType, ConsumerRecord<String, String> record, Exception exception) throws Exception;
+}

--- a/tw-tasks-executor/src/main/java/com/transferwise/tasks/helpers/kafka/messagetotask/CreateTaskForCorruptedMessageRecoveryStrategy.java
+++ b/tw-tasks-executor/src/main/java/com/transferwise/tasks/helpers/kafka/messagetotask/CreateTaskForCorruptedMessageRecoveryStrategy.java
@@ -1,0 +1,47 @@
+package com.transferwise.tasks.helpers.kafka.messagetotask;
+
+import com.transferwise.tasks.ITasksService;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+/**
+ * Recovery policy that creates a task of the given type (default {@value DEFAULT_CORRUPTED_MESSAGE_TASK_TYPE})
+ * wrapping the original "corrupted" content in {@link CorruptedKafkaMessage}.
+ * The task of created type requires manual intervention, which basically means that
+ * a dedicated handler resolving corrupted messages needs to be implemented.
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class CreateTaskForCorruptedMessageRecoveryStrategy implements CorruptedMessageRecoveryStrategy {
+
+    public static final String DEFAULT_CORRUPTED_MESSAGE_TASK_TYPE = "CORRUPTED_KAFKA_MESSAGE";
+
+    private final ITasksService tasksService;
+    private final String type;
+
+    public CreateTaskForCorruptedMessageRecoveryStrategy(ITasksService tasksService) {
+        this(tasksService, DEFAULT_CORRUPTED_MESSAGE_TASK_TYPE);
+    }
+
+    @Override
+    public void recover(Class<?> messageType, ConsumerRecord<String, String> record, Exception exception) {
+        log.error("Failed to deserialize message from topic {}, creating a {} task for it", record.topic(), type, exception);
+        tasksService.addTask(
+            new ITasksService.AddTaskRequest()
+                .setType(type)
+                .setData(new CorruptedKafkaMessage(record.topic(), record.value()))
+        );
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class CorruptedKafkaMessage {
+        private String topic;
+        private String corruptedData;
+    }
+}

--- a/tw-tasks-executor/src/main/java/com/transferwise/tasks/helpers/kafka/messagetotask/InfiniteRetryCorruptedMessageRecoveryStrategy.java
+++ b/tw-tasks-executor/src/main/java/com/transferwise/tasks/helpers/kafka/messagetotask/InfiniteRetryCorruptedMessageRecoveryStrategy.java
@@ -1,0 +1,11 @@
+package com.transferwise.tasks.helpers.kafka.messagetotask;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+/** Doesn't do any recovery, the message deserialization will be retried again. */
+public class InfiniteRetryCorruptedMessageRecoveryStrategy implements CorruptedMessageRecoveryStrategy {
+    @Override
+    public void recover(Class<?> messageType, ConsumerRecord<String, String> record, Exception exception) throws Exception {
+        throw exception;
+    }
+}

--- a/tw-tasks-executor/src/main/java/com/transferwise/tasks/helpers/kafka/messagetotask/KafkaMessageHandlerFactory.java
+++ b/tw-tasks-executor/src/main/java/com/transferwise/tasks/helpers/kafka/messagetotask/KafkaMessageHandlerFactory.java
@@ -1,0 +1,94 @@
+package com.transferwise.tasks.helpers.kafka.messagetotask;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.transferwise.tasks.ITasksService;
+import com.transferwise.tasks.utils.TriConsumer;
+import lombok.RequiredArgsConstructor;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.stereotype.Component;
+
+/** Factory for ready to use {@link IKafkaMessageHandler kafka message handlers}. */
+@Component
+@RequiredArgsConstructor
+public class KafkaMessageHandlerFactory {
+
+    private final ITasksService tasksService;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * Creates default handler, the behaviour of the handler is the same to {@link KafkaMessageToTaskConverter}.
+     * When the handler fails to deserialize a message it will infinitely attempt to deserialize the same message
+     * over and over again, the processing of the other messages in the topic will be stuck.
+     */
+    public <T> IKafkaMessageHandler<String> createDefaultHandler(
+        Class<T> dataObjClass,
+        TriConsumer<T, ConsumerRecord<String, String>, ITasksService.AddTaskRequest> consumer,
+        IKafkaMessageHandler.Topic... topics
+    ) {
+        return createResilientHandler(
+            new InfiniteRetryCorruptedMessageRecoveryStrategy(),
+            dataObjClass,
+            consumer,
+            topics
+        );
+    }
+
+    /**
+     * Creates a resilient handler, every corrupted message will be wrapped and
+     * processed separately as described in {@link CorruptedMessageRecoveryStrategy}.
+     *
+     * @see ResilientKafkaMessageHandler
+     */
+    public <T> IKafkaMessageHandler<String> createDefaultResilientHandler(
+        Class<T> dataObjClass,
+        TriConsumer<T, ConsumerRecord<String, String>, ITasksService.AddTaskRequest> consumer,
+        IKafkaMessageHandler.Topic... topics
+    ) {
+        return createResilientHandler(
+            new CreateTaskForCorruptedMessageRecoveryStrategy(tasksService),
+            dataObjClass,
+            consumer,
+            topics
+        );
+    }
+
+    /**
+     * Creates a resilient handler, every corrupted message will be wrapped and
+     * processed separately as described in {@link CorruptedMessageRecoveryStrategy}.
+     *
+     * @see ResilientKafkaMessageHandler
+     */
+    public <T> IKafkaMessageHandler<String> createDefaultResilientHandler(
+        Class<T> dataObjClass,
+        TriConsumer<T, ConsumerRecord<String, String>, ITasksService.AddTaskRequest> consumer,
+        String topicAddress
+    ) {
+        return createDefaultResilientHandler(
+            dataObjClass,
+            consumer,
+            new IKafkaMessageHandler.Topic().setAddress(topicAddress)
+        );
+    }
+
+    /**
+     * Creates a resilient handler, the decision on how to deal with
+     * corrupted messages is delegated to the given {@code recoveryStrategy}.
+     *
+     * @see ResilientKafkaMessageHandler
+     */
+    public <T> IKafkaMessageHandler<String> createResilientHandler(
+        CorruptedMessageRecoveryStrategy recoveryStrategy,
+        Class<T> dataObjClass,
+        TriConsumer<T, ConsumerRecord<String, String>, ITasksService.AddTaskRequest> consumer,
+        IKafkaMessageHandler.Topic... topics
+    ) {
+        return new ResilientKafkaMessageHandler<>(
+            objectMapper,
+            tasksService,
+            recoveryStrategy,
+            dataObjClass,
+            consumer,
+            topics
+        );
+    }
+}

--- a/tw-tasks-executor/src/main/java/com/transferwise/tasks/helpers/kafka/messagetotask/ResilientKafkaMessageHandler.java
+++ b/tw-tasks-executor/src/main/java/com/transferwise/tasks/helpers/kafka/messagetotask/ResilientKafkaMessageHandler.java
@@ -1,0 +1,73 @@
+package com.transferwise.tasks.helpers.kafka.messagetotask;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.transferwise.common.baseutils.ExceptionUtils;
+import com.transferwise.tasks.ITasksService;
+import com.transferwise.tasks.utils.TriConsumer;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * A handler similar to {@link KafkaMessageToTaskConverter} but
+ * resiliently handling corrupted (failed to deserialize) messages from kafka topic.
+ * The decision on how to handle the corrupted message is delegated to {@link CorruptedMessageRecoveryStrategy}.
+ */
+@Slf4j
+class ResilientKafkaMessageHandler<T> implements IKafkaMessageHandler<String> {
+
+    private final ObjectMapper objectMapper;
+    private final ITasksService tasksService;
+    private final CorruptedMessageRecoveryStrategy corruptedMessageRecoveryStrategy;
+    private final List<Topic> topics;
+    private final Class<T> dataObjClass;
+    private final TriConsumer<T, ConsumerRecord<String, String>, ITasksService.AddTaskRequest> consumer;
+
+    ResilientKafkaMessageHandler(ObjectMapper objectMapper,
+                                 ITasksService tasksService,
+                                 CorruptedMessageRecoveryStrategy corruptedMessageRecoveryStrategy,
+                                 Class<T> dataObjClass,
+                                 TriConsumer<T, ConsumerRecord<String, String>, ITasksService.AddTaskRequest> consumer,
+                                 Topic... topics) {
+        this.objectMapper = objectMapper;
+        this.tasksService = tasksService;
+        this.corruptedMessageRecoveryStrategy = corruptedMessageRecoveryStrategy;
+        this.dataObjClass = dataObjClass;
+        this.consumer = consumer;
+        this.topics = Arrays.asList(topics);
+    }
+
+    @Override
+    public List<Topic> getTopics() {
+        return topics;
+    }
+
+    @Override
+    public boolean handles(String checkedTopic) {
+        for (Topic topic : topics) {
+            if (checkedTopic.endsWith(topic.getAddress())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void handle(ConsumerRecord<String, String> record) {
+        T dataObj;
+        try {
+            dataObj = objectMapper.readValue(record.value(), this.dataObjClass);
+        } catch (IOException x) {
+            ExceptionUtils.doUnchecked(() -> corruptedMessageRecoveryStrategy.recover(dataObjClass, record, x));
+            return;
+        }
+
+        ITasksService.AddTaskRequest addTaskRequest = new ITasksService.AddTaskRequest();
+        if (consumer.accept(dataObj, record, addTaskRequest)) {
+            tasksService.addTask(addTaskRequest);
+        }
+    }
+}

--- a/tw-tasks-executor/src/test/groovy/com/transferwise/tasks/testappa/helpers/kafka/messagetotask/CorruptedMessageTestSetup.java
+++ b/tw-tasks-executor/src/test/groovy/com/transferwise/tasks/testappa/helpers/kafka/messagetotask/CorruptedMessageTestSetup.java
@@ -1,0 +1,51 @@
+package com.transferwise.tasks.testappa.helpers.kafka.messagetotask;
+
+import com.transferwise.tasks.handler.SimpleTaskConcurrencyPolicy;
+import com.transferwise.tasks.handler.SimpleTaskProcessingPolicy;
+import com.transferwise.tasks.handler.TaskHandlerAdapter;
+import com.transferwise.tasks.handler.interfaces.ISyncTaskProcessor;
+import com.transferwise.tasks.handler.interfaces.ITaskHandler;
+import com.transferwise.tasks.helpers.kafka.messagetotask.IKafkaMessageHandler;
+import com.transferwise.tasks.helpers.kafka.messagetotask.KafkaMessageHandlerFactory;
+import lombok.Data;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+
+@Configuration
+@SuppressWarnings("checkstyle:magicnumber")
+public class CorruptedMessageTestSetup {
+
+    public static final String KAFKA_TOPIC_WITH_CORRUPTED_MESSAGES = "topicWithCorruptedMessages";
+    public static final String TASK_TYPE = "TASK_FROM_CORRUPTED_TOPIC";
+
+    @Data
+    static class TestMessage {
+        String data;
+    }
+
+    @Bean
+    IKafkaMessageHandler<String> aHandlerForCorruptedMessagesTopic(KafkaMessageHandlerFactory factory) {
+        return factory.createDefaultResilientHandler(
+            TestMessage.class,
+            (testMessage, record, addTaskRequest) -> {
+                addTaskRequest.setType(TASK_TYPE);
+                addTaskRequest.setData(record.value());
+                return true;
+            },
+            KAFKA_TOPIC_WITH_CORRUPTED_MESSAGES
+        );
+    }
+
+    @Bean
+    ITaskHandler aTaskHandlerForMessageFromTopicContainingCorruptedMessages() {
+        return new TaskHandlerAdapter(
+            task -> task.getType().equals(TASK_TYPE),
+            (ISyncTaskProcessor) task -> new ISyncTaskProcessor.ProcessResult().setResultCode(ISyncTaskProcessor.ProcessResult.ResultCode.DONE)
+        )
+            .setConcurrencyPolicy(new SimpleTaskConcurrencyPolicy(1))
+            .setProcessingPolicy(new SimpleTaskProcessingPolicy().setMaxProcessingDuration(Duration.ofSeconds(10)));
+    }
+}
+

--- a/tw-tasks-executor/src/test/groovy/com/transferwise/tasks/testappa/helpers/kafka/messagetotask/ResilientKafkaMessageHandlerIntSpec.groovy
+++ b/tw-tasks-executor/src/test/groovy/com/transferwise/tasks/testappa/helpers/kafka/messagetotask/ResilientKafkaMessageHandlerIntSpec.groovy
@@ -1,0 +1,63 @@
+package com.transferwise.tasks.testappa.helpers.kafka.messagetotask
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.transferwise.tasks.domain.Task
+import com.transferwise.tasks.domain.TaskStatus
+import com.transferwise.tasks.helpers.kafka.messagetotask.CreateTaskForCorruptedMessageRecoveryStrategy
+import com.transferwise.tasks.impl.tokafka.test.IToKafkaTestHelper
+import com.transferwise.tasks.test.BaseIntSpec
+import org.apache.kafka.clients.producer.ProducerRecord
+import org.awaitility.Awaitility
+import org.springframework.beans.factory.annotation.Autowired
+
+import static com.transferwise.tasks.helpers.kafka.messagetotask.CreateTaskForCorruptedMessageRecoveryStrategy.DEFAULT_CORRUPTED_MESSAGE_TASK_TYPE
+
+class ResilientKafkaMessageHandlerIntSpec extends BaseIntSpec {
+
+    @Autowired
+    IToKafkaTestHelper toKafkaTestHelper
+
+    @Autowired
+    ObjectMapper objectMapper
+
+    def "corrupted message results in error task of corrupted type"() {
+        when: "send corrupted message"
+            toKafkaTestHelper.sendDirectKafkaMessage(
+                new ProducerRecord<>(
+                    CorruptedMessageTestSetup.KAFKA_TOPIC_WITH_CORRUPTED_MESSAGES,
+                    null,
+                    System.currentTimeMillis(),
+                    "key",
+                    '{"corrupted json.'
+                )
+            )
+        and: "send consistent message"
+            toKafkaTestHelper.sendDirectKafkaMessage(
+                new ProducerRecord<>(
+                    CorruptedMessageTestSetup.KAFKA_TOPIC_WITH_CORRUPTED_MESSAGES,
+                    null,
+                    System.currentTimeMillis(),
+                    "key",
+                    '{}'
+                )
+            )
+        and: "there is a message of corrupted type in error state (because no handler provided for it)"
+            List<Task> corruptedTasks = []
+            Awaitility.await().until({ ->
+                corruptedTasks = testTasksService.getTasks(DEFAULT_CORRUPTED_MESSAGE_TASK_TYPE, null, TaskStatus.ERROR)
+                corruptedTasks.size() == 1
+            })
+
+        then: "The corrupted message is properly wrapped and saved"
+            def message = objectMapper.readValue(corruptedTasks[0].data, CreateTaskForCorruptedMessageRecoveryStrategy.CorruptedKafkaMessage)
+            message.getTopic() == CorruptedMessageTestSetup.KAFKA_TOPIC_WITH_CORRUPTED_MESSAGES
+            message.getCorruptedData() == '{"corrupted json.'
+
+        and: "The further messages in the topic are processed"
+            Awaitility.await().until({ ->
+                testTasksService.getTasks(CorruptedMessageTestSetup.TASK_TYPE, null, TaskStatus.DONE).size() == 1
+            })
+    }
+}
+
+


### PR DESCRIPTION
The certain problem we faced is described in the [postmortem](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/1207206174/2020-01-22+SEV-2+Corrupt+message+blocked+kafka+processing+for+payins?focusedCommentId=1200987175#comment-1200987175). In case a corrupted message gets into the topic and we fail to deserialise it, the processing of messages of that particular type will be stuck retrying to deserialise the same message over and over again. 

Here we introduce a handler similar to the default one (KafkaMessageToTaskConverter) but also taking into account the recovery strategy in case deserialisation of the message fails.

It's proposed to support 2 recovery strategies initially.
1. No recovery (current approach same as KafkaMessageToTaskConverter).
2. Create a task of certain type (default is `CORRUPTED_KAFKA_MESSAGE`) which will end up in error state, since we won't have handler for it in place. The processing of messaging from the corresponding topic will continue, while handling of corrupted task requires dedicated effort.

Later we can implement recover strategy for more complex approach, like republishing the message to the different topic and handling it not necessarily using tw-tasks or on consumer service side. 