### PR TITLE
Add KafkaMessageHandlerFactory bean to auto configuration

### DIFF
--- a/tw-tasks-executor/src/main/java/com/transferwise/tasks/TwTasksAutoConfiguration.java
+++ b/tw-tasks-executor/src/main/java/com/transferwise/tasks/TwTasksAutoConfiguration.java
@@ -25,6 +25,7 @@ import com.transferwise.tasks.helpers.kafka.AdminClientTopicPartitionsManager;
 import com.transferwise.tasks.helpers.kafka.ITopicPartitionsManager;
 import com.transferwise.tasks.helpers.kafka.NoOpTopicPartitionsManager;
 import com.transferwise.tasks.helpers.kafka.messagetotask.CoreKafkaListener;
+import com.transferwise.tasks.helpers.kafka.messagetotask.KafkaMessageHandlerFactory;
 import com.transferwise.tasks.helpers.kafka.messagetotask.KafkaMessageHandlerRegistry;
 import com.transferwise.tasks.impl.tokafka.ToKafkaProperties;
 import com.transferwise.tasks.impl.tokafka.ToKafkaSenderService;
@@ -260,6 +261,11 @@ public class TwTasksAutoConfiguration {
     @ConditionalOnMissingBean
     public TwTasksKafkaConfiguration twTaskKafkaConfiguration(KafkaProperties kafkaProperties, KafkaTemplate<String, String> kafkaTemplate) {
         return new TwTasksKafkaConfiguration(kafkaProperties, kafkaTemplate);
+    }
+
+    @Bean
+    public KafkaMessageHandlerFactory kafkaMessageHandlerFactory(ITasksService tasksService, ObjectMapper objectMapper) {
+        return new KafkaMessageHandlerFactory(tasksService, objectMapper);
     }
 
     public static class TwTasksDataSourceProvider {

--- a/tw-tasks-executor/src/main/java/com/transferwise/tasks/helpers/kafka/messagetotask/KafkaMessageHandlerFactory.java
+++ b/tw-tasks-executor/src/main/java/com/transferwise/tasks/helpers/kafka/messagetotask/KafkaMessageHandlerFactory.java
@@ -5,10 +5,8 @@ import com.transferwise.tasks.ITasksService;
 import com.transferwise.tasks.utils.TriConsumer;
 import lombok.RequiredArgsConstructor;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.springframework.stereotype.Component;
 
 /** Factory for ready to use {@link IKafkaMessageHandler kafka message handlers}. */
-@Component
 @RequiredArgsConstructor
 public class KafkaMessageHandlerFactory {
 


### PR DESCRIPTION
Should have been done as part of the #20. If not auto configured most of the services will need to do this manually, which doesn't make much sense since the component has nothing that would require alternative configuration.