### PR TITLE
Retry Time Overflow (PISP-334)

### DIFF
--- a/tw-tasks-executor/src/main/java/com/transferwise/tasks/handler/ExponentialTaskRetryPolicy.java
+++ b/tw-tasks-executor/src/main/java/com/transferwise/tasks/handler/ExponentialTaskRetryPolicy.java
@@ -31,6 +31,10 @@ public class ExponentialTaskRetryPolicy implements ITaskRetryPolicy {
       return null;
     }
     long addedTimeMs = delay.toMillis() * (long) Math.pow(multiplier, (triesCount - 1));
+    if (addedTimeMs < 0) {
+      // avoid overflows causing dates in the past to be generated
+      addedTimeMs = Long.MAX_VALUE;
+    }
     if (maxDelay != null && addedTimeMs > maxDelay.toMillis()) {
       addedTimeMs = maxDelay.toMillis();
     }

--- a/tw-tasks-executor/src/test/java/com/transferwise/tasks/handler/ExponentialTaskRetryPolicyTest.java
+++ b/tw-tasks-executor/src/test/java/com/transferwise/tasks/handler/ExponentialTaskRetryPolicyTest.java
@@ -1,0 +1,35 @@
+package com.transferwise.tasks.handler;
+
+import com.transferwise.tasks.BaseTest;
+import com.transferwise.tasks.domain.ITask;
+import com.transferwise.tasks.domain.Task;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class ExponentialTaskRetryPolicyTest extends BaseTest {
+
+  private final ExponentialTaskRetryPolicy exponentialTaskRetryPolicy = new ExponentialTaskRetryPolicy();
+
+  @ParameterizedTest
+  @MethodSource("maxDelaySource")
+  void largeRetryCountsDoNotCauseNegativeRetryDelays(Duration maxDelay) {
+    exponentialTaskRetryPolicy.setDelay(Duration.ofSeconds(20));
+    exponentialTaskRetryPolicy.setMaxCount(Integer.MAX_VALUE);
+    exponentialTaskRetryPolicy.setMaxDelay(maxDelay);
+
+    ITask task = new Task().setProcessingTriesCount(180);
+
+    ZonedDateTime retryTime = exponentialTaskRetryPolicy.getRetryTime(task, null);
+
+    Assertions.assertTrue(retryTime.isAfter(ZonedDateTime.now(Clock.systemUTC())));
+  }
+
+  private static Stream<Duration> maxDelaySource() {
+    return Stream.of(null, Duration.ofHours(1));
+  }
+}


### PR DESCRIPTION
Ensure that the exponential retry policy does not generate retry times in the past, when the tries count is large enough to cause an overflow of the calculated number of milliseconds to retry the task after.