### PR TITLE
TaskHandlerRegistry is initializing handlers list in lazy way.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Describes notable changes.
 
+#### 1.7.2 - 2020/05/22
+- TaskHandlerRegistry is initializing handlers list in lazy way to avoid possible circular dependencies in applications.
+
 #### 1.7.1 - 2020/05/21
 - ITestTaskService got 2 new methods for controlling the automatic tasks processing:
   - `stopProcessing()`

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.7.1
+version=1.7.2
 org.gradle.internal.http.socketTimeout=120000

--- a/integration-tests/src/test/java/com/transferwise/tasks/BaseIntTest.java
+++ b/integration-tests/src/test/java/com/transferwise/tasks/BaseIntTest.java
@@ -9,6 +9,7 @@ import com.transferwise.tasks.testapp.TestTaskHandler;
 import com.transferwise.tasks.testapp.config.TestApplication;
 import com.transferwise.tasks.testapp.config.TestConfiguration;
 import com.transferwise.tasks.testapp.config.TestContainersInitializer;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 import org.awaitility.Awaitility;
@@ -46,6 +47,8 @@ public abstract class BaseIntTest {
   protected IResultRegisteringSyncTaskProcessor resultRegisteringSyncTaskProcessor;
   @Autowired
   protected TestTaskHandler testTaskHandlerAdapter;
+  @Autowired
+  protected MeterRegistry meterRegistry;
 
   @Autowired
   void setApplicationContext(ApplicationContext applicationContext) {
@@ -75,7 +78,9 @@ public abstract class BaseIntTest {
 
     // Cheap when it's already running.
     testTasksService.resumeProcessing();
-    
+
+    meterRegistry.clear();
+
     testInfo.getTestMethod().ifPresent(name ->
         log.info("Cleaning up for '{}' It took {} ms", name, System.currentTimeMillis() - startTimeMs)
     );

--- a/integration-tests/src/test/java/com/transferwise/tasks/health/ClusterWideTasksStateMonitorIntTest.java
+++ b/integration-tests/src/test/java/com/transferwise/tasks/health/ClusterWideTasksStateMonitorIntTest.java
@@ -34,6 +34,8 @@ class ClusterWideTasksStateMonitorIntTest extends BaseIntTest {
 
   @Test
   void metricsAreCorrectlyRegistered() {
+    clusterWideTasksStateMonitor.resetState(false);
+    clusterWideTasksStateMonitor.resetState(true);
     clusterWideTasksStateMonitor.check();
 
     Collection<Gauge> hlGauges = meterRegistry.get("twTasks.health.tasksHistoryLengthSeconds").gauges();

--- a/integration-tests/src/test/java/com/transferwise/tasks/testapp/TaskProcessingIntTest.java
+++ b/integration-tests/src/test/java/com/transferwise/tasks/testapp/TaskProcessingIntTest.java
@@ -18,7 +18,6 @@ import com.transferwise.tasks.handler.interfaces.ISyncTaskProcessor.ProcessResul
 import com.transferwise.tasks.handler.interfaces.ITaskProcessingPolicy;
 import com.transferwise.tasks.triggering.ITasksExecutionTriggerer;
 import com.transferwise.tasks.triggering.KafkaTasksExecutionTriggerer;
-import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import java.time.Duration;
 import java.util.List;
@@ -41,8 +40,6 @@ public class TaskProcessingIntTest extends BaseIntTest {
   protected ITaskDao taskDao;
   @Autowired
   protected ITasksExecutionTriggerer tasksExecutionTriggerer;
-  @Autowired
-  protected MeterRegistry meterRegistry;
 
   private KafkaTasksExecutionTriggerer kafkaTasksExecutionTriggerer;
 

--- a/integration-tests/src/test/java/com/transferwise/tasks/testapp/TaskResumingIntTest.java
+++ b/integration-tests/src/test/java/com/transferwise/tasks/testapp/TaskResumingIntTest.java
@@ -9,7 +9,6 @@ import com.transferwise.tasks.BaseIntTest;
 import com.transferwise.tasks.ITasksService;
 import com.transferwise.tasks.test.ITestTasksService;
 import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.MeterRegistry;
 import java.time.ZonedDateTime;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
@@ -24,8 +23,6 @@ public class TaskResumingIntTest extends BaseIntTest {
   private ITasksService tasksService;
   @Autowired
   private ITestTasksService testTasksService;
-  @Autowired
-  protected MeterRegistry meterRegistry;
 
   @BeforeEach
   void setup() {


### PR DESCRIPTION
TaskHandlerRegistry is initializing handlers list in lazy way to avoid possible circular dependencies in applications.