### PR TITLE
We are marking all buckets as dirty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Describes notable changes.
 
+#### 1.8.2 - 2020/07/09
+- We are marking all buckets as dirty, when some concurrency slot frees up. 
+To support cases where multiple buckets have the same concurrency policy.
+
 #### 1.8.1 - 2020/07/08
 - Added some debug metrics for tasks processing cycle.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.8.1
+version=1.8.2
 org.gradle.internal.http.socketTimeout=120000

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/processing/GlobalProcessingState.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/processing/GlobalProcessingState.java
@@ -22,6 +22,12 @@ public class GlobalProcessingState {
 
   private Map<String, Bucket> buckets = new ConcurrentHashMap<>();
 
+  public void increaseBucketsVersion() {
+    buckets.forEach((k, v) -> {
+      v.increaseVersion();
+    });
+  }
+
   @Data
   @Accessors(chain = true)
   public static class Bucket {


### PR DESCRIPTION
We are marking all buckets as dirty, when some concurrency slot frees up.