### PR TITLE
Optimized a TasksResumer query executed on startup for Postgres.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Describes notable changes.
 
+#### 1.11.0 - 2020/08/27
+- Optimized a TasksResumer query executed on startup for Postgres.
+Postgres was likely to decide to not use `(id,version)` and do a full scan instead.
+- Properties `minPriority` and `maxPriority` on `tw-tasks.core` were renamed to `highestPriority` and `lowestPriority`.
+It will hopefully make it more clear, that lower priority numbers mean higher chance to be executed first. 
+
 #### 1.10.1 - 2020/08/18
 - Fixes a bug, where using a max priority for a task causes a null pointer exception.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Describes notable changes.
 
 #### 1.11.0 - 2020/08/27
 - Optimized a TasksResumer query executed on startup for Postgres.
-Postgres was likely to decide to not use `(id,version)` and do a full scan instead.
+Postgres was likely to decide to not use `(status, next_event_time)` and do a full scan instead.
 - Properties `minPriority` and `maxPriority` on `tw-tasks.core` were renamed to `highestPriority` and `lowestPriority`.
 It will hopefully make it more clear, that lower priority numbers mean higher chance to be executed first. 
 

--- a/demoapp/docker/docker-compose.yml
+++ b/demoapp/docker/docker-compose.yml
@@ -72,15 +72,15 @@ services:
     --innodb_buffer_pool_size=2g
     --character-set-server=utf8mb4
     --collation-server=utf8mb4_unicode_ci --transaction-isolation=READ-COMMITTED"
-#  postgres:
-#    image: postgres:10
-#    ports:
-#      - "15432:5432"
-#    environment:
-#      POSTGRES_PASSWORD: example-password-change-me
-#    volumes:
-#      - ./postgres//postgre-initdb.d:/docker-entrypoint-initdb.d
-#    command: -c 'max_connections=200'
+  postgres:
+    image: postgres:10
+    ports:
+      - "15432:5432"
+    environment:
+      POSTGRES_PASSWORD: example-password-change-me
+    volumes:
+      - ./postgres//postgre-initdb.d:/docker-entrypoint-initdb.d
+    command: -c 'max_connections=200'
 
 networks:
   default:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.10.1
+version=1.11.0
 org.gradle.internal.http.socketTimeout=120000

--- a/integration-tests/src/test/java/com/transferwise/tasks/testapp/TaskProcessingIntTest.java
+++ b/integration-tests/src/test/java/com/transferwise/tasks/testapp/TaskProcessingIntTest.java
@@ -251,7 +251,7 @@ public class TaskProcessingIntTest extends BaseIntTest {
 
     testTasksService.resumeProcessing();
 
-    await().atMost(Duration.ofMinutes(10)).until(() -> processedPriorities.size() == 4);
+    await().until(() -> processedPriorities.size() == 4);
 
     // As task finding loop and a thread filling tasks memory table are running in parallel, it is likely, that
     // first task is not "1". Rest however should be processed in expected order.

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/IPriorityManager.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/IPriorityManager.java
@@ -2,9 +2,9 @@ package com.transferwise.tasks;
 
 public interface IPriorityManager {
 
-  int getMinPriority();
+  int getHighestPriority();
 
-  int getMaxPriority();
+  int getLowestPriority();
 
   int normalize(Integer priority);
 }

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/ITasksService.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/ITasksService.java
@@ -19,7 +19,7 @@ public interface ITasksService {
    * <p>If you want to schedule a task to run only after a specific time, provide runAfterTime value. Otherwise the task will be run immediately
    * after transaction commit. A scheduled task will be resumed by the leader node polling for it (less efficient).
    *
-   * <p>Default priority is 5. The higher the number, the higher the priority and the higher the chance the task will be run before other tasks.
+   * <p>Default priority is 5. The lower the number, the higher the priority, meaning the higher the chance the task will be run before other tasks.
    *
    * <p>If a task with provided id or key already exists, an ALREADY_EXISTS result is given.
    *

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/PriorityManager.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/PriorityManager.java
@@ -8,25 +8,25 @@ public class PriorityManager implements IPriorityManager {
   private TasksProperties tasksProperties;
 
   @Override
-  public int getMinPriority() {
-    return tasksProperties.getMinPriority();
+  public int getHighestPriority() {
+    return tasksProperties.getHighestPriority();
   }
 
   @Override
-  public int getMaxPriority() {
-    return tasksProperties.getMaxPriority();
+  public int getLowestPriority() {
+    return tasksProperties.getLowestPriority();
   }
 
   @Override
   public int normalize(Integer priority) {
     if (priority == null) {
-      return (getMaxPriority() + 1 - getMinPriority()) / 2;
+      return (getLowestPriority() + 1 - getHighestPriority()) / 2;
     }
-    if (priority > getMaxPriority()) {
-      return getMaxPriority();
+    if (priority > getLowestPriority()) {
+      return getLowestPriority();
     }
-    if (priority < getMinPriority()) {
-      return getMinPriority();
+    if (priority < getHighestPriority()) {
+      return getHighestPriority();
     }
     return priority;
   }

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/TasksProperties.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/TasksProperties.java
@@ -125,13 +125,13 @@ public class TasksProperties {
    */
   private int asyncTaskTriggeringsConcurrency = 10;
   /**
-   * Minimum task priority allowed.
+   * Highest task priority allowed.
    */
-  private int minPriority = 0;
+  private int highestPriority = 0;
   /**
-   * Maximum task priority allowed.
+   * Lowest task priority allowed.
    */
-  private int maxPriority = 9;
+  private int lowestPriority = 9;
   /**
    * When we lose the offset of a triggering topic, where do we rewind? Only used for task triggering. For usual topics listeners, the spring-kafka
    * configuration is used.
@@ -230,7 +230,7 @@ public class TasksProperties {
   private Duration interruptTasksAfterShutdownTime = null;
 
   private boolean debugMetricsEnabled = false;
-  
+
   public enum DbType {
     MYSQL, POSTGRES
   }

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/buckets/BucketsManager.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/buckets/BucketsManager.java
@@ -57,7 +57,7 @@ public class BucketsManager implements IBucketsManager {
 
     for (String bucketId : bucketIds) {
       globalProcessingState.getBuckets().put(bucketId,
-          new GlobalProcessingState.Bucket(priorityManager.getMinPriority(), priorityManager.getMaxPriority())
+          new GlobalProcessingState.Bucket(priorityManager.getHighestPriority(), priorityManager.getLowestPriority())
               .setBucketId(bucketId));
     }
   }

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/dao/MySqlTaskDao.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/dao/MySqlTaskDao.java
@@ -289,8 +289,8 @@ public class MySqlTaskDao implements ITaskDao {
     Timestamp now = Timestamp.from(ZonedDateTime.now(TwContextClockHolder.getClock()).toInstant());
     List<StuckTask> result = new ArrayList<>();
 
-    // We use this to make PostgreSql to always prefer the (id, version) index.
-    // Otherwise we had cases were we end up in full-scan.
+    // We use this to make PostgreSql to always prefer the `(status, next_event_time)` index.
+    // Otherwise we had cases were we ended up with db full-scan.
     Timestamp nextEventTimeFrom =
         Timestamp.from(ZonedDateTime.now(TwContextClockHolder.getClock()).minus(tasksProperties.getStuckTaskAge().multipliedBy(2)).toInstant());
 


### PR DESCRIPTION
- Optimized a TasksResumer query executed on startup for Postgres.
Postgres was likely to decide to not use `(status, next_event_time)` and do a full scan instead.
- Properties `minPriority` and `maxPriority` on `tw-tasks.core` were renamed to `highestPriority` and `lowestPriority`.
It will hopefully make it more clear, that lower priority numbers mean higher chance to be executed first.

https://transferwise.slack.com/archives/C7P9L0B6Z/p1598451235020500
https://transferwise.slack.com/archives/C7P9L0B6Z/p1598353005015100