### PR TITLE
Small hygiene changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Describes notable changes.
 
+#### 1.12.0 - 2020/08/31
+- Moving away from deprecated LeaderSelector to LeaderSelectorV2.
+- Added new metric `twTasks.task.addings.count` for tracking adding of new tasks.
+- Background jobs start and stop messages contain `group.id`.
+It allows quickly to understand, if some service is using another service's identifier.
+- Upgraded external libraries to latest.
+
 #### 1.11.0 - 2020/08/27
 - Optimized a TasksResumer query executed on startup for Postgres.
 Postgres was likely to decide to not use `(status, next_event_time)` and do a full scan instead.

--- a/build.libraries.gradle
+++ b/build.libraries.gradle
@@ -1,7 +1,7 @@
 ext {
-    twContextVersion = "0.4.0"
+    twContextVersion = "0.5.0"
     twLeaderSelectorVersion = "1.3.1"
-    springBootVersion = "2.2.8.RELEASE"
+    springBootVersion = "2.3.3.RELEASE"
 
 
     libraries = [
@@ -11,7 +11,7 @@ ext {
             apacheCommonsCollections    : "org.apache.commons:commons-collections4:4.4",
             commonsIo                   : "commons-io:commons-io:2.6",
             guava                       : "com.google.guava:guava:29.0-jre",
-            twGracefulShutdown          : "com.transferwise.common:tw-graceful-shutdown:1.2.8",
+            twGracefulShutdown          : "com.transferwise.common:tw-graceful-shutdown:1.2.9",
             twGracefulShutdownIntefaces : "com.transferwise.common:tw-graceful-shutdown-interfaces:1.3.2",
             twContext                   : "com.transferwise.common:tw-context:${twContextVersion}",
             twContextStarter            : "com.transferwise.common:tw-context-starter:${twContextVersion}",

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.11.0
+version=1.12.0
 org.gradle.internal.http.socketTimeout=120000

--- a/integration-tests/src/test/resources/config/application.yml
+++ b/integration-tests/src/test/resources/config/application.yml
@@ -6,6 +6,7 @@ spring:
       request.timeout.ms: 11000
       session.timeout.ms: 10000
       max.partition.fetch.bytes: 10485760
+      partitioner.class: org.apache.kafka.clients.producer.RoundRobinPartitioner
     producer:
       acks: 'all'
     consumer:

--- a/tw-tasks-core-spring-boot-starter/src/main/java/com/transferwise/tasks/core/autoconfigure/TwTasksCoreAutoConfiguration.java
+++ b/tw-tasks-core-spring-boot-starter/src/main/java/com/transferwise/tasks/core/autoconfigure/TwTasksCoreAutoConfiguration.java
@@ -130,23 +130,8 @@ public class TwTasksCoreAutoConfiguration {
 
   @Bean
   @ConditionalOnMissingBean(ITasksResumer.class)
-  public TasksResumer twTasksTasksResumer(
-      ITasksExecutionTriggerer tasksExecutionTriggerer,
-      ITaskHandlerRegistry taskHandlerRegistry,
-      TasksProperties tasksProperties,
-      ITaskDao taskDao,
-      CuratorFramework curatorFramework,
-      IExecutorServicesProvider executorServicesProvider,
-      IMeterHelper meterHelper) {
-    return new TasksResumer(
-        tasksExecutionTriggerer,
-        taskHandlerRegistry,
-        tasksProperties,
-        taskDao,
-        curatorFramework,
-        executorServicesProvider,
-        meterHelper
-    );
+  public TasksResumer twTasksTasksResumer() {
+    return new TasksResumer();
   }
 
   @Bean

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/TasksService.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/TasksService.java
@@ -108,6 +108,8 @@ public class TasksService implements ITasksService, GracefulShutdownStrategy {
               .setType(request.getType()).setTaskId(request.getTaskId())
               .setMaxStuckTime(maxStuckTime).setStatus(status).setPriority(priority));
 
+      meterHelper.registerTaskAdding(request.getType(), request.getKey(), insertTaskResponse.isInserted(), request.getRunAfterTime(), data);
+      
       if (!insertTaskResponse.isInserted()) {
         meterHelper.registerDuplicateTask(request.getType(), !request.isWarnWhenTaskExists());
         if (request.isWarnWhenTaskExists()) {

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/helpers/IMeterHelper.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/helpers/IMeterHelper.java
@@ -2,6 +2,7 @@ package com.transferwise.tasks.helpers;
 
 import com.transferwise.tasks.domain.TaskStatus;
 import com.transferwise.tasks.processing.TasksProcessingService.ProcessTaskResponse;
+import java.time.ZonedDateTime;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -64,4 +65,6 @@ public interface IMeterHelper {
   void debugRoomMapAlreadyHasType(String bucketId, int priority, String taskType);
 
   void debugTaskTriggeringQueueEmpty(String bucketId, int priority, String taskType);
+
+  void registerTaskAdding(String type, String key, boolean inserted, ZonedDateTime runAfterTime, String data);
 }

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/helpers/MicrometerMeterHelper.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/helpers/MicrometerMeterHelper.java
@@ -201,9 +201,14 @@ public class MicrometerMeterHelper implements IMeterHelper {
 
   @Override
   public void registerTaskAdding(String type, String key, boolean inserted, ZonedDateTime runAfterTime, String data) {
-    meterRegistry.counter(METRIC_TASKS_ADDINGS_COUNT, TAG_TASK_TYPE, type, TAG_HAS_KEY, key == null ? "false" : "true",
-        TAG_IS_DUPLICATE, inserted ? "false" : "true", TAG_IS_SCHEDULED, runAfterTime == null ? "false" : "true", TAG_DATA_SIZE,
-        getDataSizeBucket(data));
+    meterRegistry.counter(
+        METRIC_TASKS_ADDINGS_COUNT,
+        TAG_TASK_TYPE, type,
+        TAG_HAS_KEY, Boolean.toString(key != null),
+        TAG_IS_DUPLICATE, Boolean.toString(!inserted),
+        TAG_IS_SCHEDULED, Boolean.toString(runAfterTime != null),
+        TAG_DATA_SIZE, getDataSizeBucket(data)
+    ).increment();
   }
 
   @Override

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/helpers/MicrometerMeterHelper.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/helpers/MicrometerMeterHelper.java
@@ -8,6 +8,7 @@ import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Tags;
+import java.time.ZonedDateTime;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
@@ -24,15 +25,46 @@ import org.apache.commons.lang3.tuple.Triple;
 @Slf4j
 public class MicrometerMeterHelper implements IMeterHelper {
 
+  private static final String METRIC_TASKS_MARKED_AS_ERROR_COUNT = METRIC_PREFIX + "tasks.markedAsErrorCount";
+  private static final String METRIC_TASKS_PROCESSINGS_COUNT = METRIC_PREFIX + "tasks.processingsCount";
+  private static final String METRIC_TASKS_ONGOING_PROCESSINGS_COUNT = METRIC_PREFIX + "tasks.ongoingProcessingsCount";
+  private static final String METRIC_TASKS_PROCESSED_COUNT = METRIC_PREFIX + "tasks.processedCount";
+  private static final String METRIC_TASKS_PROCESSING_TIME = METRIC_PREFIX + "tasks.processingTime";
+  private static final String METRIC_TASKS_FAILED_STATUS_CHANGE_COUNT = METRIC_PREFIX + "tasks.failedStatusChangeCount";
+  private static final String METRIC_TASKS_DEBUG_PRIORITY_QUEUE_CHECK = METRIC_PREFIX + "tasks.debug.priorityQueueCheck";
+  private static final String METRIC_TASKS_TASK_GRABBING = METRIC_PREFIX + "tasks.taskGrabbing";
+  private static final String METRIC_TASKS_DEBUG_ROOM_MAP_ALREADY_HAS_TYPE = METRIC_PREFIX + "tasks.debug.roomMapAlreadyHasType";
+  private static final String METRIC_TASKS_DEBUG_TASK_TRIGGERING_QUEUE_EMPTY = METRIC_PREFIX + "tasks.debug.taskTriggeringQueueEmpty";
+  private static final String METRIC_CORE_KAFKA_PROCESSED_MESSAGES_COUNT = METRIC_PREFIX + "coreKafka.processedMessagesCount";
+  private static final String METRIC_TASKS_DUPLICATES_COUNT = METRIC_PREFIX + "tasks.duplicatesCount";
+  private static final String METRIC_TASKS_RESUMER_SCHEDULED_TASKS_RESUMED_COUNT = METRIC_PREFIX + "tasksResumer.scheduledTasks.resumedCount";
+  private static final String METRIC_TASKS_RESUMER_STUCK_TASKS_MARK_FAILED_COUNT = METRIC_PREFIX + "tasksResumer.stuckTasks.markFailedCount";
+  private static final String METRIC_TASKS_RESUMER_STUCK_TASKS_IGNORED_COUNT = METRIC_PREFIX + "tasksResumer.stuckTasks.ignoredCount";
+  private static final String METRIC_TASKS_RESUMER_STUCK_TASKS_RESUMED_COUNT = METRIC_PREFIX + "tasksResumer.stuckTasks.resumedCount";
+  private static final String METRIC_TASKS_RESUMER_STUCK_TASKS_MARK_ERROR_COUNT = METRIC_PREFIX + "tasksResumer.stuckTasks.markErrorCount";
+  private static final String METRIC_TASKS_RESUMER_STUCK_TASKS_CLIENT_RESUMED_COUNT = METRIC_PREFIX + "tasksResumer.stuckTasks.clientResumedCount";
+  private static final String METRIC_TASKS_FAILED_GRABBINGS_COUNT = METRIC_PREFIX + "tasks.failedGrabbingsCount";
+  private static final String METRIC_TASKS_RETRIES_COUNT = METRIC_PREFIX + "tasks.retriesCount";
+  private static final String METRIC_TASKS_RESUMINGS_COUNT = METRIC_PREFIX + "tasks.resumingsCount";
+  private static final String METRIC_TASKS_MARKED_AS_FAILED_COUNT = METRIC_PREFIX + "tasks.markedAsFailedCount";
+  private static final String METRIC_TASKS_ADDINGS_COUNT = METRIC_PREFIX + "task.addings.count";
+
+  private static final String TAG_PROCESSING_RESULT = "processingResult";
+  private static final String TAG_FROM_STATUS = "fromStatus";
+  private static final String TAG_TO_STATUS = "toStatus";
   private static final String TAG_BUCKET_ID = "bucketId";
   private static final String TAG_TASK_TYPE = "taskType";
   private static final String TAG_REASON = "reason";
   private static final String TAG_PRIORITY = "priority";
   private static final String TAG_GRABBING_RESPONSE = "grabbingResponse";
   private static final String TAG_GRABBING_CODE = "grabbingCode";
-  private static String TAG_PROCESSING_RESULT = "processingResult";
-  private static String TAG_FROM_STATUS = "fromStatus";
-  private static String TAG_TO_STATUS = "toStatus";
+  private static final String TAG_HAS_KEY = "hasKey";
+  private static final String TAG_IS_DUPLICATE = "isDuplicate";
+  private static final String TAG_IS_SCHEDULED = "isScheduled";
+  private static final String TAG_DATA_SIZE = "dataSize";
+
+  private static final String[] DATA_SIZE_BUCKET_VALUES = {"64", "256", "1024", "4096", "16384", "65536"};
+  private static final int[] DATA_SIZE_BUCKETS = {64, 256, 1024, 4096, 16384, 65536};
 
   private final MeterRegistry meterRegistry;
 
@@ -40,18 +72,18 @@ public class MicrometerMeterHelper implements IMeterHelper {
 
   @Override
   public void registerTaskMarkedAsError(String bucketId, String taskType) {
-    meterRegistry.counter(METRIC_PREFIX + "tasks.markedAsErrorCount", TAG_BUCKET_ID, resolveBucketId(bucketId), TAG_TASK_TYPE, taskType).increment();
+    meterRegistry.counter(METRIC_TASKS_MARKED_AS_ERROR_COUNT, TAG_BUCKET_ID, resolveBucketId(bucketId), TAG_TASK_TYPE, taskType).increment();
   }
 
   @Override
   public void registerTaskProcessingStart(String bucketId, String taskType) {
     String resolvedBucketId = resolveBucketId(bucketId);
-    meterRegistry.counter(METRIC_PREFIX + "tasks.processingsCount", TAG_BUCKET_ID, resolvedBucketId, TAG_TASK_TYPE, taskType).increment();
+    meterRegistry.counter(METRIC_TASKS_PROCESSINGS_COUNT, TAG_BUCKET_ID, resolvedBucketId, TAG_TASK_TYPE, taskType).increment();
 
     gauges.computeIfAbsent(Triple.of("tasks.ongoingProcessingsCount", resolvedBucketId, taskType), (t) -> {
       AtomicInteger counter = new AtomicInteger(0);
       meterRegistry
-          .gauge(METRIC_PREFIX + "tasks.ongoingProcessingsCount", Tags.of(TAG_BUCKET_ID, resolvedBucketId, TAG_TASK_TYPE, taskType), counter);
+          .gauge(METRIC_TASKS_ONGOING_PROCESSINGS_COUNT, Tags.of(TAG_BUCKET_ID, resolvedBucketId, TAG_TASK_TYPE, taskType), counter);
       return counter;
     }).incrementAndGet();
   }
@@ -59,9 +91,9 @@ public class MicrometerMeterHelper implements IMeterHelper {
   @Override
   public void registerTaskProcessingEnd(String bucketId, String taskType, long processingStartTimeMs, String processingResult) {
     String resolvedBucketId = resolveBucketId(bucketId);
-    meterRegistry.counter(METRIC_PREFIX + "tasks.processedCount", TAG_BUCKET_ID, resolvedBucketId, TAG_TASK_TYPE, taskType,
+    meterRegistry.counter(METRIC_TASKS_PROCESSED_COUNT, TAG_BUCKET_ID, resolvedBucketId, TAG_TASK_TYPE, taskType,
         TAG_PROCESSING_RESULT, processingResult).increment();
-    meterRegistry.timer(METRIC_PREFIX + "tasks.processingTime", TAG_BUCKET_ID, resolvedBucketId, TAG_TASK_TYPE, taskType,
+    meterRegistry.timer(METRIC_TASKS_PROCESSING_TIME, TAG_BUCKET_ID, resolvedBucketId, TAG_TASK_TYPE, taskType,
         TAG_PROCESSING_RESULT, processingResult)
         .record(TwContextClockHolder.getClock().millis() - processingStartTimeMs, TimeUnit.MILLISECONDS);
     gauges.get(Triple.of("tasks.ongoingProcessingsCount", resolvedBucketId, taskType)).decrementAndGet();
@@ -69,13 +101,13 @@ public class MicrometerMeterHelper implements IMeterHelper {
 
   @Override
   public void registerFailedStatusChange(String taskType, String fromStatus, TaskStatus toStatus) {
-    meterRegistry.counter(METRIC_PREFIX + "tasks.failedStatusChangeCount", TAG_TASK_TYPE, taskType,
+    meterRegistry.counter(METRIC_TASKS_FAILED_STATUS_CHANGE_COUNT, TAG_TASK_TYPE, taskType,
         TAG_FROM_STATUS, fromStatus, TAG_TO_STATUS, toStatus.name()).increment();
   }
 
   @Override
   public void registerTaskGrabbingResponse(String bucketId, String taskType, int priority, ProcessTaskResponse processTaskResponse) {
-    meterRegistry.counter(METRIC_PREFIX + "tasks.taskGrabbing", TAG_TASK_TYPE, taskType,
+    meterRegistry.counter(METRIC_TASKS_TASK_GRABBING, TAG_TASK_TYPE, taskType,
         TAG_BUCKET_ID, bucketId, TAG_PRIORITY, String.valueOf(priority), TAG_GRABBING_RESPONSE, processTaskResponse.getResult().name(),
         TAG_GRABBING_CODE, processTaskResponse.getCode() == null ? "UNKNOWN" : processTaskResponse.getCode().name())
         .increment();
@@ -83,88 +115,95 @@ public class MicrometerMeterHelper implements IMeterHelper {
 
   @Override
   public void debugPriorityQueueCheck(String bucketId, int priority) {
-    meterRegistry.counter(METRIC_PREFIX + "tasks.debug.priorityQueueCheck", TAG_BUCKET_ID, bucketId, TAG_PRIORITY, String.valueOf(priority))
+    meterRegistry.counter(METRIC_TASKS_DEBUG_PRIORITY_QUEUE_CHECK, TAG_BUCKET_ID, bucketId, TAG_PRIORITY, String.valueOf(priority))
         .increment();
   }
 
   @Override
   public void debugRoomMapAlreadyHasType(String bucketId, int priority, String taskType) {
-    meterRegistry.counter(METRIC_PREFIX + "tasks.debug.roomMapAlreadyHasType", TAG_BUCKET_ID, bucketId, TAG_PRIORITY, String.valueOf(priority),
+    meterRegistry.counter(METRIC_TASKS_DEBUG_ROOM_MAP_ALREADY_HAS_TYPE, TAG_BUCKET_ID, bucketId, TAG_PRIORITY, String.valueOf(priority),
         TAG_TASK_TYPE, taskType).increment();
   }
 
   @Override
   public void debugTaskTriggeringQueueEmpty(String bucketId, int priority, String taskType) {
-    meterRegistry.counter(METRIC_PREFIX + "tasks.debug.taskTriggeringQueueEmpty", TAG_BUCKET_ID, bucketId, TAG_PRIORITY, String.valueOf(priority),
+    meterRegistry.counter(METRIC_TASKS_DEBUG_TASK_TRIGGERING_QUEUE_EMPTY, TAG_BUCKET_ID, bucketId, TAG_PRIORITY, String.valueOf(priority),
         TAG_TASK_TYPE, taskType).increment();
   }
 
   @Override
   public void registerKafkaCoreMessageProcessing(int shard, String topic) {
-    meterRegistry.counter(METRIC_PREFIX + "coreKafka.processedMessagesCount", Tags.of("topic", topic, "shard", String.valueOf(shard))).increment();
+    meterRegistry.counter(METRIC_CORE_KAFKA_PROCESSED_MESSAGES_COUNT, Tags.of("topic", topic, "shard", String.valueOf(shard))).increment();
   }
 
   @Override
   public void registerDuplicateTask(String taskType, boolean expected) {
-    meterRegistry.counter(METRIC_PREFIX + "tasks.duplicatesCount", TAG_TASK_TYPE, taskType, "expected", String.valueOf(expected)).increment();
+    meterRegistry.counter(METRIC_TASKS_DUPLICATES_COUNT, TAG_TASK_TYPE, taskType, "expected", String.valueOf(expected)).increment();
   }
 
   @Override
   public void registerScheduledTaskResuming(String taskType) {
-    meterRegistry.counter(METRIC_PREFIX + "tasksResumer.scheduledTasks.resumedCount", TAG_TASK_TYPE, taskType).increment();
+    meterRegistry.counter(METRIC_TASKS_RESUMER_SCHEDULED_TASKS_RESUMED_COUNT, TAG_TASK_TYPE, taskType).increment();
   }
 
   @Override
   public void registerStuckTaskMarkedAsFailed(String taskType) {
-    meterRegistry.counter(METRIC_PREFIX + "tasksResumer.stuckTasks.markFailedCount", TAG_TASK_TYPE, taskType).increment();
+    meterRegistry.counter(METRIC_TASKS_RESUMER_STUCK_TASKS_MARK_FAILED_COUNT, TAG_TASK_TYPE, taskType).increment();
   }
 
   @Override
   public void registerStuckTaskAsIgnored(String taskType) {
-    meterRegistry.counter(METRIC_PREFIX + "tasksResumer.stuckTasks.ignoredCount", TAG_TASK_TYPE, taskType).increment();
+    meterRegistry.counter(METRIC_TASKS_RESUMER_STUCK_TASKS_IGNORED_COUNT, TAG_TASK_TYPE, taskType).increment();
   }
 
   @Override
   public void registerStuckTaskResuming(String taskType) {
-    meterRegistry.counter(METRIC_PREFIX + "tasksResumer.stuckTasks.resumedCount", TAG_TASK_TYPE, taskType).increment();
+    meterRegistry.counter(METRIC_TASKS_RESUMER_STUCK_TASKS_RESUMED_COUNT, TAG_TASK_TYPE, taskType).increment();
   }
 
   @Override
   public void registerStuckTaskMarkedAsError(String taskType) {
-    meterRegistry.counter(METRIC_PREFIX + "tasksResumer.stuckTasks.markErrorCount", TAG_TASK_TYPE, taskType).increment();
+    meterRegistry.counter(METRIC_TASKS_RESUMER_STUCK_TASKS_MARK_ERROR_COUNT, TAG_TASK_TYPE, taskType).increment();
   }
 
   @Override
   public void registerStuckClientTaskResuming(String taskType) {
-    meterRegistry.counter(METRIC_PREFIX + "tasksResumer.stuckTasks.clientResumedCount", TAG_TASK_TYPE, taskType).increment();
+    meterRegistry.counter(METRIC_TASKS_RESUMER_STUCK_TASKS_CLIENT_RESUMED_COUNT, TAG_TASK_TYPE, taskType).increment();
   }
 
   @Override
   public void registerFailedTaskGrabbing(String bucketId, String taskType) {
-    meterRegistry.counter(METRIC_PREFIX + "tasks.failedGrabbingsCount", TAG_BUCKET_ID, resolveBucketId(bucketId), TAG_TASK_TYPE, taskType)
+    meterRegistry.counter(METRIC_TASKS_FAILED_GRABBINGS_COUNT, TAG_BUCKET_ID, resolveBucketId(bucketId), TAG_TASK_TYPE, taskType)
         .increment();
   }
 
   @Override
   public void registerTaskRetryOnError(String bucketId, String taskType) {
-    meterRegistry.counter(METRIC_PREFIX + "tasks.retriesCount", TAG_BUCKET_ID, resolveBucketId(bucketId), TAG_TASK_TYPE, taskType,
+    meterRegistry.counter(METRIC_TASKS_RETRIES_COUNT, TAG_BUCKET_ID, resolveBucketId(bucketId), TAG_TASK_TYPE, taskType,
         TAG_REASON, "ERROR").increment();
   }
 
   @Override
   public void registerTaskRetry(String bucketId, String taskType) {
-    meterRegistry.counter(METRIC_PREFIX + "tasks.retriesCount", TAG_BUCKET_ID, resolveBucketId(bucketId), TAG_TASK_TYPE, taskType,
+    meterRegistry.counter(METRIC_TASKS_RETRIES_COUNT, TAG_BUCKET_ID, resolveBucketId(bucketId), TAG_TASK_TYPE, taskType,
         TAG_REASON, "CONTINUE").increment();
   }
 
   @Override
   public void registerTaskResuming(String bucketId, String taskType) {
-    meterRegistry.counter(METRIC_PREFIX + "tasks.resumingsCount", TAG_BUCKET_ID, resolveBucketId(bucketId), TAG_TASK_TYPE, taskType).increment();
+    meterRegistry.counter(METRIC_TASKS_RESUMINGS_COUNT, TAG_BUCKET_ID, resolveBucketId(bucketId), TAG_TASK_TYPE, taskType).increment();
   }
 
   @Override
   public void registerTaskMarkedAsFailed(String bucketId, String taskType) {
-    meterRegistry.counter(METRIC_PREFIX + "tasks.markedAsFailedCount", TAG_BUCKET_ID, resolveBucketId(bucketId), TAG_TASK_TYPE, taskType).increment();
+    meterRegistry.counter(METRIC_TASKS_MARKED_AS_FAILED_COUNT, TAG_BUCKET_ID, resolveBucketId(bucketId), TAG_TASK_TYPE, taskType).increment();
+  }
+
+  @Override
+  public void registerTaskAdding(String type, String key, boolean inserted, ZonedDateTime runAfterTime, String data) {
+    meterRegistry.counter(METRIC_TASKS_ADDINGS_COUNT, TAG_TASK_TYPE, type, TAG_HAS_KEY, key == null ? "false" : "true",
+        TAG_IS_DUPLICATE, inserted ? "false" : "true", TAG_IS_SCHEDULED, runAfterTime == null ? "false" : "true", TAG_DATA_SIZE,
+        getDataSizeBucket(data));
   }
 
   @Override
@@ -201,4 +240,15 @@ public class MicrometerMeterHelper implements IMeterHelper {
     }
     return Tags.empty();
   }
+  
+  protected String getDataSizeBucket(String data) {
+    int dataSize = data == null ? 0 : data.length();
+    for (int i = 0; i < DATA_SIZE_BUCKETS.length; i++) {
+      if (dataSize < DATA_SIZE_BUCKETS[i]) {
+        return DATA_SIZE_BUCKET_VALUES[i];
+      }
+    }
+    return "HUGE";
+  }
+
 }

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/helpers/NoOpMeterHelper.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/helpers/NoOpMeterHelper.java
@@ -2,6 +2,7 @@ package com.transferwise.tasks.helpers;
 
 import com.transferwise.tasks.domain.TaskStatus;
 import com.transferwise.tasks.processing.TasksProcessingService.ProcessTaskResponse;
+import java.time.ZonedDateTime;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -125,5 +126,10 @@ public class NoOpMeterHelper implements IMeterHelper {
   @Override
   public void debugTaskTriggeringQueueEmpty(String bucketId, int priority, String taskType) {
 
+  }
+  
+  @Override
+  public void registerTaskAdding(String type, String key, boolean inserted, ZonedDateTime runAfterTime, String data){
+    
   }
 }

--- a/tw-tasks-kafka-listener-spring-boot-starter/build.gradle
+++ b/tw-tasks-kafka-listener-spring-boot-starter/build.gradle
@@ -39,7 +39,7 @@ dockerCompose {
 
     // Set to true if you have anomalies
     stopContainers = true
-    removeContainers = false
+    removeContainers = true
 
     environment.put "KAFKA_RANDOM_PORT", "${freePort}"
 }

--- a/tw-tasks-kafka-publisher/src/main/java/com/transferwise/tasks/impl/tokafka/ToKafkaTaskHandlerConfiguration.java
+++ b/tw-tasks-kafka-publisher/src/main/java/com/transferwise/tasks/impl/tokafka/ToKafkaTaskHandlerConfiguration.java
@@ -85,7 +85,7 @@ public class ToKafkaTaskHandlerConfiguration {
 
   private void registerSentMessage(String topic) {
     if (meterRegistry != null) {
-      meterRegistry.counter(IMeterHelper.METRIC_PREFIX + "toKafka.sentMessagesCount", Tags.of("topic", topic));
+      meterRegistry.counter(IMeterHelper.METRIC_PREFIX + "toKafka.sentMessagesCount", Tags.of("topic", topic)).increment();
     }
   }
 }


### PR DESCRIPTION
- Moving away from deprecated LeaderSelector to LeaderSelectorV2.
- Added new metric `twTasks.task.addings.count` for tracking adding of new tasks.
- Background jobs start and stop messages contain `group.id`.
It allows quickly to understand, if some service is using another service's identifier.
- Upgraded external libraries to latest.