### PR TITLE
Old tasks are now cleaned by ids only and not checking their versions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Describes notable changes.
 
+#### 1.13.0 - 2020/09/10
+- Old tasks are now cleaned by ids only and not checking their versions. It allows to execute multivalue queries, which should be more efficient.
+Previous situation can be set by `TasksProperties.paranoidTasksCleaning=true`.
+
 #### 1.12.0 - 2020/08/31
 - Moving away from deprecated LeaderSelector to LeaderSelectorV2.
 - Added new metric `twTasks.task.addings.count` for tracking adding of new tasks.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.12.1
+version=1.13.0
 org.gradle.internal.http.socketTimeout=120000

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/TasksProperties.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/TasksProperties.java
@@ -230,6 +230,8 @@ public class TasksProperties {
   private Duration interruptTasksAfterShutdownTime = null;
 
   private boolean debugMetricsEnabled = false;
+  
+  private boolean paranoidTasksCleaning = false;
 
   public enum DbType {
     MYSQL, POSTGRES

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/processing/GlobalProcessingState.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/processing/GlobalProcessingState.java
@@ -81,8 +81,8 @@ public class GlobalProcessingState {
       if (ttA == ttB) {
         return 0;
       }
-      TaskTriggering ttAPeek = ttA.getTasks().peek();
-      TaskTriggering ttBPeek = ttB.getTasks().peek();
+      TaskTriggering ttAPeek = ttA.peek();
+      TaskTriggering ttBPeek = ttB.peek();
       if (ttAPeek == null && ttBPeek != null) {
         return 1;
       } else if (ttAPeek != null && ttBPeek == null) {
@@ -106,7 +106,26 @@ public class GlobalProcessingState {
   public static class TypeTasks {
 
     private String type;
+    private AtomicInteger size = new AtomicInteger();
     private Queue<TaskTriggering> tasks = new ConcurrentLinkedQueue<>();
+
+    public TaskTriggering peek() {
+      return tasks.peek();
+    }
+
+    public TaskTriggering poll() {
+      TaskTriggering taskTriggering = tasks.poll();
+      if (taskTriggering != null) {
+        size.decrementAndGet();
+      }
+      return taskTriggering;
+    }
+
+    public void add(TaskTriggering taskTriggering) {
+      if (tasks.add(taskTriggering)) {
+        size.incrementAndGet();
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Context

Tasks cleaning seem to take a lot of IO on innodbs.

### Changes

We start cleaning by multivalue queries, which should be more efficient.
Previous situation can be set by `TasksProperties.paranoidTasksCleaning=true`.

## Checklist
- [ ] I have considered the impact of this change and added a [Change Classification](
https://transferwise.atlassian.net/wiki/spaces/EKB/pages/1401189673/Change+Classifications+and+Expectations) Label (`change:standard`, `change:impactful`, `change:emergency`)
- [ ] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
