### PR TITLE
Stop logging parititon warn on every startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,16 @@
 
 Describes notable changes.
 
+#### 1.15.1 - 2020/20/16
+- Partitions manager will log a warn only when a topic is missing or configured number of partitions is different from existing ones.
+
 #### 1.15.0 - 2020/10/14
 - Switched away from testcontainers, used docker-compose plugin for all integration tests.
 - Removed support for xRequestId.
 
 #### 1.14.2 - 2020/09/27
 - Minor bugfixes for approximate tasks count in the database, related to multi schema setups.
-- MySQL INSERT IGNORE has additional checks to make sure the failure was about duplicate records and not about something else. 
+- MySQL INSERT IGNORE has additional checks to make sure the failure was about duplicate records and not about something else.
 
 #### 1.14.1 - 2020/09/21
 - Added metrics for knowing approximate tasks count in the database.
@@ -25,18 +28,18 @@ https://www.informit.com/articles/article.aspx?p=25862
 https://www.2ndquadrant.com/en/blog/sequential-uuid-generators/
 https://en.wikipedia.org/wiki/Universally_unique_identifier#As_database_keys
 
-- (id,version) index was removed on Postgres as well, making db perf test to run 25% faster. 
+- (id,version) index was removed on Postgres as well, making db perf test to run 25% faster.
 
 - MariaDb schema for new services was redesigned.
 However, the code is still working and keeps working with older schema as well.
 
 - Another, more optimal table schema was tested and proposed for MariaDb applications which for whatever reasons are forced
-to use random UUIDs with large number of tw tasks. 
+to use random UUIDs with large number of tw tasks.
 
 - Added a db perf test to `demoapp` and `DemoAppRealTest`, which is more suitable to compare database bottlenecks tests.
 
 - When a task is being set to a final state, the next_event_time is set to current time.
-This will make the task cleaning process more accurate. 
+This will make the task cleaning process more accurate.
 
 #### 1.13.0 - 2020/09/10
 - Old tasks are now cleaned by ids only and not checking their versions. It allows to execute multivalue queries, which should be more efficient.
@@ -53,7 +56,7 @@ It allows quickly to understand, if some service is using another service's iden
 - Optimized a TasksResumer query executed on startup for Postgres.
 Postgres was likely to decide to not use `(status, next_event_time)` and do a full scan instead.
 - Properties `minPriority` and `maxPriority` on `tw-tasks.core` were renamed to `highestPriority` and `lowestPriority`.
-It will hopefully make it more clear, that lower priority numbers mean higher chance to be executed first. 
+It will hopefully make it more clear, that lower priority numbers mean higher chance to be executed first.
 
 #### 1.10.1 - 2020/08/18
 - Fixes a bug, where using a max priority for a task causes a null pointer exception.
@@ -64,7 +67,7 @@ It is useful in scenarios where low latency processing is desired for a specific
 The downside of multiple shards is having more KafkaConsumers per application, possibly increasing the load on Kafka server.
 - tw-leader-selector was upgraded, it now brings in tw-curator.
 This in turn means, that you don't have to define a CuratorFramework bean in your application, it will be created
-automatically if missing. 
+automatically if missing.
 
 #### 1.9.0 - 2020/07/10
 - Optimized some queries for a case where there is enormous number of waiting or stuck tasks.
@@ -73,7 +76,7 @@ automatically if missing.
 - Debug metrics are disabled by default.
 
 #### 1.8.2 - 2020/07/09
-- We are marking all buckets as dirty, when some concurrency slot frees up. 
+- We are marking all buckets as dirty, when some concurrency slot frees up.
 To support cases where multiple buckets have the same concurrency policy.
 
 #### 1.8.1 - 2020/07/08

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.15.0
+version=1.15.1
 org.gradle.internal.http.socketTimeout=120000

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/helpers/kafka/NoOpTopicPartitionsManager.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/helpers/kafka/NoOpTopicPartitionsManager.java
@@ -1,12 +1,51 @@
 package com.transferwise.tasks.helpers.kafka;
 
+import com.transferwise.common.baseutils.ExceptionUtils;
+import com.transferwise.tasks.config.TwTasksKafkaConfiguration;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.DescribeTopicsResult;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
+import org.springframework.beans.factory.annotation.Autowired;
 
 @Slf4j
 public class NoOpTopicPartitionsManager implements ITopicPartitionsManager {
 
+  private static final int COMMANDS_TIMEOUT_S = 30;
+
+  @Autowired
+  private TwTasksKafkaConfiguration kafkaConfiguration;
+
   @Override
   public void setPartitionsCount(String topic, int partitionsCount) {
-    log.warn("Not trying to set partitions count to " + partitionsCount + " for topic '" + topic + "'.");
+    ExceptionUtils.doUnchecked(() -> {
+      AdminClient adminClient = AdminClient.create(kafkaConfiguration.getKafkaProperties().buildAdminProperties());
+      try {
+        DescribeTopicsResult describeTopicsResult = adminClient.describeTopics(Arrays.asList(topic));
+        TopicDescription topicDescription = null;
+        try {
+          topicDescription = describeTopicsResult.all().get(COMMANDS_TIMEOUT_S, TimeUnit.SECONDS).get(topic);
+        } catch (ExecutionException e) {
+          if (e.getCause() == null || !(e.getCause() instanceof UnknownTopicOrPartitionException)) {
+            throw e;
+          }
+        }
+        if (topicDescription == null) {
+          log.warn("Topic '" + topic + "' doesn't exist.");
+        } else {
+          int currentPartitionsCount = topicDescription.partitions().size();
+          if (currentPartitionsCount < partitionsCount) {
+            log.warn("Topic '" + topic + "' has " + currentPartitionsCount + " instead of configured " + partitionsCount + ".");
+          }
+        }
+      } finally {
+        adminClient.close(Duration.ofSeconds(COMMANDS_TIMEOUT_S));
+      }
+    });
   }
 }


### PR DESCRIPTION
## Context

Currently there is a warning about "Not setting a number of partitions" logged on every app startup.
We've agreed to replace this implementation of the partition manager with the one that actually checks the existence of topic/correct number of partitions first and logs an exception in case it's not correct.
https://transferwise.slack.com/archives/C7P9L0B6Z/p1597654390362100

## Checklist
- [X] I have considered the impact of this change and added a [Change Classification](
https://transferwise.atlassian.net/wiki/spaces/EKB/pages/1401189673/Change+Classifications+and+Expectations) Label (`change:standard`, `change:impactful`, `change:emergency`)
- [X] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
