### PR TITLE
Allowing most beans defined by auto configuration to be overridden.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Describes notable changes.
 
+#### 1.19.0 - 2020/11/01
+- Allowing most beans defined by auto configuration to be overridden.
+
 #### 1.18.0 - 2020/11/01
 - MDC corrections.
 Following MDC keys are now set for tasks under processing:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.18.0
+version=1.19.0
 org.gradle.internal.http.socketTimeout=120000

--- a/tw-tasks-core-spring-boot-starter/src/main/java/com/transferwise/tasks/core/autoconfigure/ITwTasksDataSourceProvider.java
+++ b/tw-tasks-core-spring-boot-starter/src/main/java/com/transferwise/tasks/core/autoconfigure/ITwTasksDataSourceProvider.java
@@ -1,0 +1,8 @@
+package com.transferwise.tasks.core.autoconfigure;
+
+import javax.sql.DataSource;
+
+public interface ITwTasksDataSourceProvider {
+
+  DataSource getDataSource();
+}

--- a/tw-tasks-core-spring-boot-starter/src/main/java/com/transferwise/tasks/core/autoconfigure/TwTasksDataSourceProvider.java
+++ b/tw-tasks-core-spring-boot-starter/src/main/java/com/transferwise/tasks/core/autoconfigure/TwTasksDataSourceProvider.java
@@ -2,7 +2,7 @@ package com.transferwise.tasks.core.autoconfigure;
 
 import javax.sql.DataSource;
 
-public class TwTasksDataSourceProvider implements ITwTasksDataSourceProvider{
+public class TwTasksDataSourceProvider implements ITwTasksDataSourceProvider {
 
   private final DataSource dataSource;
 

--- a/tw-tasks-core-spring-boot-starter/src/main/java/com/transferwise/tasks/core/autoconfigure/TwTasksDataSourceProvider.java
+++ b/tw-tasks-core-spring-boot-starter/src/main/java/com/transferwise/tasks/core/autoconfigure/TwTasksDataSourceProvider.java
@@ -1,0 +1,17 @@
+package com.transferwise.tasks.core.autoconfigure;
+
+import javax.sql.DataSource;
+
+public class TwTasksDataSourceProvider implements ITwTasksDataSourceProvider{
+
+  private final DataSource dataSource;
+
+  public TwTasksDataSourceProvider(DataSource dataSource) {
+    this.dataSource = dataSource;
+  }
+
+  @Override
+  public DataSource getDataSource() {
+    return dataSource;
+  }
+}

--- a/tw-tasks-incidents-spring-boot-starter/src/main/java/com/transferwise/tasks/ext/incidents/autoconfigure/TwTasksExtIncidentsAutoConfiguration.java
+++ b/tw-tasks-incidents-spring-boot-starter/src/main/java/com/transferwise/tasks/ext/incidents/autoconfigure/TwTasksExtIncidentsAutoConfiguration.java
@@ -1,6 +1,7 @@
 package com.transferwise.tasks.ext.incidents.autoconfigure;
 
 import com.transferwise.tasks.health.TasksIncidentGenerator;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -8,6 +9,7 @@ import org.springframework.context.annotation.Configuration;
 public class TwTasksExtIncidentsAutoConfiguration {
 
   @Bean
+  @ConditionalOnMissingBean
   public TasksIncidentGenerator tasksIncidentGenerator() {
     return new TasksIncidentGenerator();
   }

--- a/tw-tasks-kafka-listener-spring-boot-starter/src/main/java/com/transferwise/tasks/ext/kafkalistener/autoconfigure/TwTasksExtKafkaListenerAutoConfiguration.java
+++ b/tw-tasks-kafka-listener-spring-boot-starter/src/main/java/com/transferwise/tasks/ext/kafkalistener/autoconfigure/TwTasksExtKafkaListenerAutoConfiguration.java
@@ -16,7 +16,7 @@ import org.springframework.context.annotation.Configuration;
 public class TwTasksExtKafkaListenerAutoConfiguration {
 
   @Bean
-  @ConditionalOnMissingBean(CoreKafkaListener.class)
+  @ConditionalOnMissingBean
   @SuppressWarnings("rawtypes")
   public CoreKafkaListener twTasksCoreKafkaListener() {
     return new CoreKafkaListener();
@@ -30,7 +30,7 @@ public class TwTasksExtKafkaListenerAutoConfiguration {
   }
 
   @Bean
-  @ConditionalOnMissingBean(KafkaMessageHandlerFactory.class)
+  @ConditionalOnMissingBean
   public KafkaMessageHandlerFactory kafkaMessageHandlerFactory(ITasksService tasksService, ObjectMapper objectMapper) {
     return new KafkaMessageHandlerFactory(tasksService, objectMapper);
   }

--- a/tw-tasks-kafka-listener-spring-boot-starter/src/main/java/com/transferwise/tasks/ext/kafkalistener/autoconfigure/TwTasksExtKafkaListenerAutoConfiguration.java
+++ b/tw-tasks-kafka-listener-spring-boot-starter/src/main/java/com/transferwise/tasks/ext/kafkalistener/autoconfigure/TwTasksExtKafkaListenerAutoConfiguration.java
@@ -3,8 +3,10 @@ package com.transferwise.tasks.ext.kafkalistener.autoconfigure;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.transferwise.tasks.ITasksService;
 import com.transferwise.tasks.helpers.kafka.messagetotask.CoreKafkaListener;
+import com.transferwise.tasks.helpers.kafka.messagetotask.IKafkaMessageHandlerRegistry;
 import com.transferwise.tasks.helpers.kafka.messagetotask.KafkaMessageHandlerFactory;
 import com.transferwise.tasks.helpers.kafka.messagetotask.KafkaMessageHandlerRegistry;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -14,18 +16,21 @@ import org.springframework.context.annotation.Configuration;
 public class TwTasksExtKafkaListenerAutoConfiguration {
 
   @Bean
+  @ConditionalOnMissingBean(CoreKafkaListener.class)
   @SuppressWarnings("rawtypes")
   public CoreKafkaListener twTasksCoreKafkaListener() {
     return new CoreKafkaListener();
   }
 
   @Bean
+  @ConditionalOnMissingBean(IKafkaMessageHandlerRegistry.class)
   @SuppressWarnings("rawtypes")
   public KafkaMessageHandlerRegistry twTasksKafkaMessageHandlerRegistry() {
     return new KafkaMessageHandlerRegistry();
   }
 
   @Bean
+  @ConditionalOnMissingBean(KafkaMessageHandlerFactory.class)
   public KafkaMessageHandlerFactory kafkaMessageHandlerFactory(ITasksService tasksService, ObjectMapper objectMapper) {
     return new KafkaMessageHandlerFactory(tasksService, objectMapper);
   }

--- a/tw-tasks-kafka-publisher-spring-boot-starter/src/main/java/com/transferwise/tasks/ext/kafkapublisher/autoconfigure/TwTasksExtKafkaPublisherAutoConfiguration.java
+++ b/tw-tasks-kafka-publisher-spring-boot-starter/src/main/java/com/transferwise/tasks/ext/kafkapublisher/autoconfigure/TwTasksExtKafkaPublisherAutoConfiguration.java
@@ -2,9 +2,11 @@ package com.transferwise.tasks.ext.kafkapublisher.autoconfigure;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.transferwise.tasks.ITasksService;
+import com.transferwise.tasks.impl.tokafka.IToKafkaSenderService;
 import com.transferwise.tasks.impl.tokafka.ToKafkaProperties;
 import com.transferwise.tasks.impl.tokafka.ToKafkaSenderService;
 import com.transferwise.tasks.impl.tokafka.ToKafkaTaskHandlerConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -17,6 +19,7 @@ import org.springframework.context.annotation.Import;
 public class TwTasksExtKafkaPublisherAutoConfiguration {
 
   @Bean
+  @ConditionalOnMissingBean(IToKafkaSenderService.class)
   public ToKafkaSenderService twTasksToKafkaSenderService(
       ObjectMapper objectMapper, ITasksService taskService, ToKafkaProperties properties) {
     return new ToKafkaSenderService(objectMapper, taskService, properties.getBatchSizeMb());

--- a/tw-tasks-management-spring-boot-starter/src/main/java/com/transferwise/tasks/ext/management/autoconfigure/TwTasksExtManagementAutoConfiguration.java
+++ b/tw-tasks-management-spring-boot-starter/src/main/java/com/transferwise/tasks/ext/management/autoconfigure/TwTasksExtManagementAutoConfiguration.java
@@ -1,7 +1,8 @@
 package com.transferwise.tasks.ext.management.autoconfigure;
 
 import com.transferwise.tasks.TasksProperties;
-import com.transferwise.tasks.core.autoconfigure.TwTasksCoreAutoConfiguration.TwTasksDataSourceProvider;
+import com.transferwise.tasks.core.autoconfigure.TwTasksDataSourceProvider;
+import com.transferwise.tasks.management.ITasksManagementService;
 import com.transferwise.tasks.management.TasksManagementPortController;
 import com.transferwise.tasks.management.TasksManagementService;
 import com.transferwise.tasks.management.dao.IManagementTaskDao;
@@ -17,17 +18,20 @@ public class TwTasksExtManagementAutoConfiguration {
 
   @Bean
   @ConditionalOnProperty(value = "tw-tasks.core.db-type", havingValue = "POSTGRES")
-  public IManagementTaskDao postgresManagementTaskDao(TwTasksDataSourceProvider twTasksDataSourceProvider, TasksProperties tasksProperties) {
+  @ConditionalOnMissingBean(IManagementTaskDao.class)
+  public PostgresManagementTaskDao postgresManagementTaskDao(TwTasksDataSourceProvider twTasksDataSourceProvider, TasksProperties tasksProperties) {
     return new PostgresManagementTaskDao(twTasksDataSourceProvider.getDataSource(), tasksProperties);
   }
 
   @Bean
   @ConditionalOnProperty(value = "tw-tasks.core.db-type", havingValue = "MYSQL")
-  public IManagementTaskDao mysqlManagementTaskDao(TwTasksDataSourceProvider twTasksDataSourceProvider, TasksProperties tasksProperties) {
+  @ConditionalOnMissingBean(IManagementTaskDao.class)
+  public MySqlManagementTaskDao mysqlManagementTaskDao(TwTasksDataSourceProvider twTasksDataSourceProvider, TasksProperties tasksProperties) {
     return new MySqlManagementTaskDao(twTasksDataSourceProvider.getDataSource(), tasksProperties);
   }
 
   @Bean
+  @ConditionalOnMissingBean(ITasksManagementService.class)
   public TasksManagementService twTasksTasksManagementService() {
     return new TasksManagementService();
   }


### PR DESCRIPTION
## Context

Some legacy apps may need to override any bean.

### Changes

Allowing most beans defined by auto configuration to be overridden.

## Checklist
- [ ] I have considered the impact of this change and added a [Change Classification](
https://transferwise.atlassian.net/wiki/spaces/EKB/pages/1401189673/Change+Classifications+and+Expectations) Label (`change:standard`, `change:impactful`, `change:emergency`)
- [ ] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
