### PR TITLE
pass AdminClientConfig.client-id as empty so kafka will generate auto…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Describes notable changes.
 
+#### 1.19.1 - 2020/11/10
+- Fix AdminClient Jmx registration issue.
+
 #### 1.19.0 - 2020/11/01
 - Allowing most beans defined by auto configuration to be overridden.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.19.0
+version=1.19.1
 org.gradle.internal.http.socketTimeout=120000

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/helpers/kafka/AdminClientTopicPartitionsManager.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/helpers/kafka/AdminClientTopicPartitionsManager.java
@@ -34,6 +34,8 @@ public class AdminClientTopicPartitionsManager implements ITopicPartitionsManage
   public void setPartitionsCount(String topic, int partitionsCount) {
     ExceptionUtils.doUnchecked(() -> {
       Map<String, Object> adminConfig = kafkaConfiguration.getKafkaProperties().buildAdminProperties();
+      //we are passing empty client-id, this will generate auto increment id with format: "adminclient-" + ADMIN_CLIENT_ID_SEQUENCE.getAndIncrement()
+      //see https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java#generateClientId
       adminConfig.put(AdminClientConfig.CLIENT_ID_CONFIG, "");
       AdminClient adminClient = AdminClient.create(adminConfig);
       //noinspection TryFinallyCanBeTryWithResources

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/helpers/kafka/AdminClientTopicPartitionsManager.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/helpers/kafka/AdminClientTopicPartitionsManager.java
@@ -7,10 +7,12 @@ import com.transferwise.tasks.TasksProperties;
 import com.transferwise.tasks.config.TwTasksKafkaConfiguration;
 import java.time.Duration;
 import java.util.Collections;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.DescribeTopicsResult;
 import org.apache.kafka.clients.admin.NewPartitions;
 import org.apache.kafka.clients.admin.NewTopic;
@@ -31,7 +33,9 @@ public class AdminClientTopicPartitionsManager implements ITopicPartitionsManage
   @Override
   public void setPartitionsCount(String topic, int partitionsCount) {
     ExceptionUtils.doUnchecked(() -> {
-      AdminClient adminClient = AdminClient.create(kafkaConfiguration.getKafkaProperties().buildAdminProperties());
+      Map<String, Object> adminConfig = kafkaConfiguration.getKafkaProperties().buildAdminProperties();
+      adminConfig.put(AdminClientConfig.CLIENT_ID_CONFIG, "");
+      AdminClient adminClient = AdminClient.create(adminConfig);
       //noinspection TryFinallyCanBeTryWithResources
       try {
         DescribeTopicsResult describeTopicsResult = adminClient.describeTopics(Collections.singletonList(topic));


### PR DESCRIPTION
…-incremented id


## Context

Resolves #73 

### Changes

When creating the AdminClient, we build the AdminClientConfig from the produce one, which pass the client-id, as we create as a transient class and close it immediately, we can pass the client-id here as empty then kafka will generate auto-increment id for it see https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/clients/admin/KafkaAdminClient.java#L437

## Checklist
- [x] I have considered the impact of this change and added a [Change Classification](
https://transferwise.atlassian.net/wiki/spaces/EKB/pages/1401189673/Change+Classifications+and+Expectations) Label (`change:standard`, `change:impactful`, `change:emergency`)
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
