### PR TITLE
Processing policy can define if task is deleted once finished

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Describes notable changes.
 
+#### 1.20.0 - 2020/11/14
+- `ITaskProcessingPolicy` now offers configuration option to delete a task after successful execution. Disabled by default.
+- Automatic tasks removal is now enabled for `SendToKafka` tasks (the task type used by the tw-tasks-ext-kafka-publisher).
+
 #### 1.19.2 - 2020/11/11
 - Remove AdminClientTopicPartitionsManager and remove configureKafkaTopics.
   You need to remove the configuration property: `tw-tasks.core.configure-kafka-topics`.

--- a/integration-tests/src/test/java/com/transferwise/tasks/testapp/TaskProcessingIntTest.java
+++ b/integration-tests/src/test/java/com/transferwise/tasks/testapp/TaskProcessingIntTest.java
@@ -359,7 +359,7 @@ public class TaskProcessingIntTest extends BaseIntTest {
       });
     }
 
-    testTaskHandlerAdapter.setProcessingPolicy(new SimpleTaskProcessingPolicy().setDeleteOnFinish(true));
+    testTaskHandlerAdapter.setProcessingPolicy(new SimpleTaskProcessingPolicy().setDeleteTaskOnFinish(true));
 
     UUID taskId = UuidUtils.generatePrefixCombUuid();
     transactionsHelper.withTransaction().asNew().call(() ->

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/TasksProperties.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/TasksProperties.java
@@ -153,10 +153,7 @@ public class TasksProperties {
    * situation. Can use TCP/IP flow control algorithms.
    */
   private int tasksHistoryDeletingBatchSize = 2 * 125;
-
-  //TODO: This does not make sense as generic parameter.
-  //      taskhandler should provide this info programmatically.
-  //      No usage so far in Tw
+  
   /**
    * Should we delete a task immediately after it has marked as DONE. Maybe in the future the task handler can provide this information.
    *

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/handler/SimpleTaskProcessingPolicy.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/handler/SimpleTaskProcessingPolicy.java
@@ -36,6 +36,10 @@ public class SimpleTaskProcessingPolicy implements ITaskProcessingPolicy {
   @Accessors(chain = true)
   private StuckTaskResolutionStrategy stuckTaskResolutionStrategy = StuckTaskResolutionStrategy.MARK_AS_ERROR;
 
+  @Setter
+  @Accessors(chain = true)
+  private boolean deleteOnFinish;
+
   @Override
   public String getProcessingBucket(IBaseTask task) {
     return processingBucket;
@@ -69,5 +73,10 @@ public class SimpleTaskProcessingPolicy implements ITaskProcessingPolicy {
   @Override
   public String getOwner(IBaseTask task) {
     return owner;
+  }
+
+  @Override
+  public boolean deleteTaskOnFinish() {
+    return deleteOnFinish;
   }
 }

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/handler/SimpleTaskProcessingPolicy.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/handler/SimpleTaskProcessingPolicy.java
@@ -38,7 +38,7 @@ public class SimpleTaskProcessingPolicy implements ITaskProcessingPolicy {
 
   @Setter
   @Accessors(chain = true)
-  private boolean deleteOnFinish;
+  private boolean deleteTaskOnFinish;
 
   @Override
   public String getProcessingBucket(IBaseTask task) {
@@ -77,6 +77,6 @@ public class SimpleTaskProcessingPolicy implements ITaskProcessingPolicy {
 
   @Override
   public boolean deleteTaskOnFinish() {
-    return deleteOnFinish;
+    return deleteTaskOnFinish;
   }
 }

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/handler/interfaces/ITaskProcessingPolicy.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/handler/interfaces/ITaskProcessingPolicy.java
@@ -49,4 +49,14 @@ public interface ITaskProcessingPolicy {
   default boolean canExecuteTaskOnThisNode(IBaseTask task) {
     return true;
   }
+
+  /**
+   * Returns true if the task should be deleted after successful execution,
+   * otherwise task will be kept and deleted later by cleaner as configured.
+   *
+   * <p>Note that task id based uniqueness guarantees are lost if task is deleted.
+   */
+  default boolean deleteTaskOnFinish() {
+    return false;
+  }
 }

--- a/tw-tasks-kafka-publisher/src/main/java/com/transferwise/tasks/impl/tokafka/ToKafkaTaskHandlerConfiguration.java
+++ b/tw-tasks-kafka-publisher/src/main/java/com/transferwise/tasks/impl/tokafka/ToKafkaTaskHandlerConfiguration.java
@@ -70,7 +70,7 @@ public class ToKafkaTaskHandlerConfiguration {
         .setProcessingPolicy(
             new SimpleTaskProcessingPolicy()
                 .setMaxProcessingDuration(Duration.ofMillis(toKafkaProperties.getMaxProcessingDurationMs()))
-                .setDeleteOnFinish(true)
+                .setDeleteTaskOnFinish(true)
         )
         .setRetryPolicy(
             new ExponentialTaskRetryPolicy()

--- a/tw-tasks-kafka-publisher/src/main/java/com/transferwise/tasks/impl/tokafka/ToKafkaTaskHandlerConfiguration.java
+++ b/tw-tasks-kafka-publisher/src/main/java/com/transferwise/tasks/impl/tokafka/ToKafkaTaskHandlerConfiguration.java
@@ -66,11 +66,19 @@ public class ToKafkaTaskHandlerConfiguration {
                     });
           }
         })
-    ).setConcurrencyPolicy(new SimpleTaskConcurrencyPolicy(toKafkaProperties.getMaxConcurrency())).setProcessingPolicy(
-        new SimpleTaskProcessingPolicy().setMaxProcessingDuration(Duration.ofMillis(toKafkaProperties.getMaxProcessingDurationMs()))).setRetryPolicy(
-        new ExponentialTaskRetryPolicy().setDelay(Duration.ofMillis(toKafkaProperties.getRetryDelayMs()))
-            .setMultiplier(toKafkaProperties.getRetryExponent())
-            .setMaxCount(toKafkaProperties.getRetryMaxCount()).setMaxDelay(Duration.ofMillis(toKafkaProperties.getRetryMaxDelayMs())));
+    ).setConcurrencyPolicy(new SimpleTaskConcurrencyPolicy(toKafkaProperties.getMaxConcurrency()))
+        .setProcessingPolicy(
+            new SimpleTaskProcessingPolicy()
+                .setMaxProcessingDuration(Duration.ofMillis(toKafkaProperties.getMaxProcessingDurationMs()))
+                .setDeleteOnFinish(true)
+        )
+        .setRetryPolicy(
+            new ExponentialTaskRetryPolicy()
+                .setDelay(Duration.ofMillis(toKafkaProperties.getRetryDelayMs()))
+                .setMultiplier(toKafkaProperties.getRetryExponent())
+                .setMaxCount(toKafkaProperties.getRetryMaxCount())
+                .setMaxDelay(Duration.ofMillis(toKafkaProperties.getRetryMaxDelayMs()))
+        );
   }
 
   private List<Header> toKafkaHeaders(Multimap<String, byte[]> headers) {
@@ -78,9 +86,9 @@ public class ToKafkaTaskHandlerConfiguration {
       return null;
     }
     return headers.entries()
-            .stream()
-            .map(header -> new RecordHeader(header.getKey(), header.getValue()))
-            .collect(Collectors.toList());
+        .stream()
+        .map(header -> new RecordHeader(header.getKey(), header.getValue()))
+        .collect(Collectors.toList());
   }
 
   private void registerSentMessage(String topic) {


### PR DESCRIPTION
## Context

Currently tasks remain in the database until cleaner removes them, this can be tweaked by `TasksProperties#deleteTaskOnFinish` but for all the tasks. With more granular control options library users will be able to save on db space and have less processing time spent on batch cleaning.

### Changes
- `ITaskProcessingPolicy` allows defining whether task is cleaned after the execution.
- `SendToKafka` tasks are now automatically removed.
