### PR TITLE
Removes `copyDataToTwTaskField` property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Describes notable changes.
 
+#### 1.22.0 - 2020/01/06
+- Removes `copyDataToTwTaskField` property and sets `1.21.1` as minimum upgradable version.
+We don't write into old `data` field anymore.
+
 #### 1.21.1 - 2020/01/03
 - Task data is still saved into old data field, to allow seamless upgrade process.
 When upgrade from versions before 1.21.1 is finished, i.e. all cluster nodes have the new version;

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.21.1
+version=1.22.0
 org.gradle.internal.http.socketTimeout=120000

--- a/integration-tests/src/test/java/com/transferwise/tasks/testapp/TaskDataIntTest.java
+++ b/integration-tests/src/test/java/com/transferwise/tasks/testapp/TaskDataIntTest.java
@@ -46,7 +46,6 @@ public class TaskDataIntTest extends BaseIntTest {
 
   private CompressionAlgorithm originalAlgorithm;
   private int originalMinSize;
-  private boolean originalCopyDataToTwTaskField;
 
   @BeforeEach
   public void setup() {
@@ -54,14 +53,12 @@ public class TaskDataIntTest extends BaseIntTest {
     originalMinSize = tasksProperties.getCompression().getMinSize();
     tasksProperties.getCompression().setAlgorithm(CompressionAlgorithm.GZIP);
     tasksProperties.getCompression().setMinSize(100);
-    originalCopyDataToTwTaskField = tasksProperties.isCopyDataToTwTaskField();
   }
 
   @AfterEach
   public void cleanup() {
     tasksProperties.getCompression().setAlgorithm(originalAlgorithm);
     tasksProperties.getCompression().setMinSize(originalMinSize);
-    tasksProperties.setCopyDataToTwTaskField(originalCopyDataToTwTaskField);
   }
 
   private static Stream<Arguments> compressionWorksInput() {
@@ -123,27 +120,8 @@ public class TaskDataIntTest extends BaseIntTest {
   }
 
   @Test
-  void oldDataFieldIsSetForNewTasks() {
-    testTasksService.stopProcessing();
-
-    String data = "Hello World!";
-    AddTaskRequest addTaskRequest = new AddTaskRequest().setType("test_data").setData(data.getBytes(StandardCharsets.UTF_8));
-    AddTaskResponse addTaskResponse = testTasksService.addTask(addTaskRequest);
-    UUID taskId = addTaskResponse.getTaskId();
-
-    FullTaskRecord fullTaskRecord = taskDao.getTask(taskId, FullTaskRecord.class);
-    assertThat(fullTaskRecord.getData()).isEqualTo(data.getBytes(StandardCharsets.UTF_8));
-
-    String oldData = jdbcTemplate
-        .queryForObject("select data from tw_task where id=?", new Object[]{taskSqlMapper.uuidToSqlTaskId(taskId)}, String.class);
-
-    assertThat(oldData).isEqualTo(data);
-  }
-
-  @Test
   void oldDataFieldIsNotSetForNewTasks() {
     testTasksService.stopProcessing();
-    tasksProperties.setCopyDataToTwTaskField(false);
 
     String data = "Hello World!";
     AddTaskRequest addTaskRequest = new AddTaskRequest().setType("test_data").setData(data.getBytes(StandardCharsets.UTF_8));

--- a/integration-tests/src/test/resources/config/application.yml
+++ b/integration-tests/src/test/resources/config/application.yml
@@ -29,7 +29,7 @@ tw-tasks:
       algorithm: random
       minSize: 0 # Pretty much forcing compression to always happen, so it will be tested through
     environment:
-      previousVersion: "1.20.0"
+      previousVersion: "1.21.1"
 
 logging.level.com.transferwise.tasks: DEBUG
 logging.level.kafka: WARN

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/EnvironmentValidator.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/EnvironmentValidator.java
@@ -16,9 +16,11 @@ public class EnvironmentValidator implements IEnvironmentValidator {
       throw new IllegalStateException("Previous version has not been specified.");
     }
 
-    new Semver(previousVersion);
+    Semver previousSemver = new Semver(previousVersion);
+    Semver minimumRequiredPreviousSemver = new Semver("1.21.1");
 
-    // Future checks. This version allows to upgrade from any earlier versions.
+    if (previousSemver.compareTo(minimumRequiredPreviousSemver) < 0) {
+      throw new IllegalStateException("This version requires at least '" + minimumRequiredPreviousSemver + "' to be deployed first.");
+    }
   }
-
 }

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/TasksProperties.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/TasksProperties.java
@@ -254,20 +254,6 @@ public class TasksProperties {
   private boolean paranoidTasksCleaning = false;
 
   /**
-   * Copies data to old data field as well.
-   *
-   * <p>Temporary property helping to roll out 1.21.+ version from older minor versions.
-   *
-   * <p>When we are rolling out a new version, nodes with old version need to be able to process new tasks created by nodes with the new version.
-   * For that, if this property is `true`, we are copying the binary data into the old tw_task.data field as a string.
-   *
-   * <p>Once all the nodes have 1.21.+ version and there is no risk of needing a rollback, the property should be set as false.
-   *
-   * <p>Will be removed in 1.22.0.
-   */
-  private boolean copyDataToTwTaskField = true;
-
-  /**
    * Cluster wide tasks state monitoring options.
    */
   private ClusterWideTasksStateMonitor clusterWideTasksStateMonitor = new ClusterWideTasksStateMonitor();

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/dao/MySqlTaskDao.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/dao/MySqlTaskDao.java
@@ -222,12 +222,8 @@ public class MySqlTaskDao implements ITaskDao {
       Connection con = DataSourceUtils.getConnection(dataSource);
       try {
         try (PreparedStatement ps = con.prepareStatement(insertTaskSql)) {
-          String data = "";
-          if (tasksProperties.isCopyDataToTwTaskField() && request.getData() != null) {
-            data = new String(request.getData(), StandardCharsets.UTF_8);
-          }
           args(taskId, request.getType(), request.getSubType(),
-              request.getStatus(), data, nextEventTime, now, now, now, 0, 0, request.getPriority())
+              request.getStatus(), "", nextEventTime, now, now, now, 0, 0, request.getPriority())
               .setValues(ps);
 
           int insertedCount = ps.executeUpdate();


### PR DESCRIPTION
## Context

Binary data.

### Changes

Sets `1.21.1` as minimum upgradable version.

We don't write into old `data` field anymore.

## Checklist
- [ ] I have considered the impact of this change and added a [Change Classification](
https://transferwise.atlassian.net/wiki/spaces/EKB/pages/1401189673/Change+Classifications+and+Expectations) Label (`change:standard`, `change:impactful`, `change:emergency`)
- [ ] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
