### PR TITLE
Allow custom role configurations per task type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Describes notable changes.
 
+#### 1.25.0 - 2021/03/10
+- Support type-level task management configuration `tw-tasks.core.tasks-management.custom`
+
 #### 1.24.0 - 2021/02/18
 - Core and tasks triggering system does not depend on Spring Kafka, nor it's configuration.
   Services have to now specify `tw-tasks.core.triggering.kafka.bootstrap-servers` parameter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Describes notable changes.
 
 #### 1.25.0 - 2021/03/10
-- Support type-level task management configuration `tw-tasks.core.tasks-management.custom`
+- Support type-level task management configuration `tw-tasks.core.tasks-management.type-specific`
 
 #### 1.24.0 - 2021/02/18
 - Core and tasks triggering system does not depend on Spring Kafka, nor it's configuration.

--- a/README.md
+++ b/README.md
@@ -469,15 +469,15 @@ tw-tasks:
 ```
 
 You can also set type-level configuration for roles allowed. These will override the global configuration above.
-- `tw-tasks.core.tasks-management.custom`
+- `tw-tasks.core.tasks-management.type-specific`
 
 ```yaml
 tw-tasks:
   core:
     tasks-management:
-      custom:
+      type-specific:
         -
-          taskType: "myTaskType"
+          task-type: "myTaskType"
           view-task-data-roles:
             - ROLE_PAYIN_DEVEL
 ```

--- a/README.md
+++ b/README.md
@@ -468,6 +468,20 @@ tw-tasks:
         - ROLE_TW_TASK_VIEW
 ```
 
+You can also set type-level configuration for roles allowed. These will override the global configuration above.
+- `tw-tasks.core.tasks-management.custom`
+
+```yaml
+tw-tasks:
+  core:
+    tasks-management:
+      custom:
+        -
+          taskType: "myTaskType"
+          view-task-data-roles:
+            - ROLE_PAYIN_DEVEL
+```
+
 ### Custom Kafka Configuration
 `tw-tasks` library can be configured with custom Kafka config by defining `TwTasksKafkaConfiguration` bean in your application:
 ```java

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.24.0
+version=1.25.0
 org.gradle.internal.http.socketTimeout=120000

--- a/integration-tests/src/test/java/com/transferwise/tasks/testapp/TasksManagementPortIntTest.java
+++ b/integration-tests/src/test/java/com/transferwise/tasks/testapp/TasksManagementPortIntTest.java
@@ -242,7 +242,7 @@ public class TasksManagementPortIntTest extends BaseIntTest {
 
   @SneakyThrows
   @Test
-  void wrongRoleCannotViewTaskDataForCustomConfiguration() {
+  void wrongRoleCannotViewTaskDataForTypeSpecificConfiguration() {
     final UUID task0Id = transactionsHelper.withTransaction().asNew().call(() ->
         TaskTestBuilder.newTask()
             .withType("customType")
@@ -260,7 +260,7 @@ public class TasksManagementPortIntTest extends BaseIntTest {
 
   @SneakyThrows
   @Test
-  void rightRoleCanViewTaskDataForCustomConfiguration() {
+  void rightRoleCanViewTaskDataForTypeSpecificConfiguration() {
     final UUID task0Id = transactionsHelper.withTransaction().asNew().call(() ->
         TaskTestBuilder.newTask()
             .withType("customType")

--- a/integration-tests/src/test/java/com/transferwise/tasks/testapp/TasksManagementPortIntTest.java
+++ b/integration-tests/src/test/java/com/transferwise/tasks/testapp/TasksManagementPortIntTest.java
@@ -221,15 +221,59 @@ public class TasksManagementPortIntTest extends BaseIntTest {
   @SneakyThrows
   @Test
   void wrongRoleCannotViewTaskData() {
+    final UUID task0Id = transactionsHelper.withTransaction().asNew().call(() ->
+        TaskTestBuilder.newTask()
+            .inStatus(TaskStatus.ERROR)
+            .withMaxStuckTime(ZonedDateTime.now().plusDays(1))
+            .save()
+            .getTaskId()
+    );
+
     ResponseEntity<GetTaskDataResponse> dataResponse = goodEngineerTemplate()
-        .getForEntity("/v1/twTasks/task/99e30d10-a085-4708-9591-d5159ff1056c/data", GetTaskDataResponse.class);
+        .getForEntity("/v1/twTasks/task/" + task0Id + "/data", GetTaskDataResponse.class);
 
     assertThat(dataResponse.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
 
     dataResponse = badEngineerTemplate()
-        .getForEntity("/v1/twTasks/task/99e30d10-a085-4708-9591-d5159ff1056c/data", GetTaskDataResponse.class);
+        .getForEntity("/v1/twTasks/task/" + task0Id + "/data", GetTaskDataResponse.class);
 
     assertThat(dataResponse.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+  }
+
+  @SneakyThrows
+  @Test
+  void wrongRoleCannotViewTaskDataForCustomConfiguration() {
+    final UUID task0Id = transactionsHelper.withTransaction().asNew().call(() ->
+        TaskTestBuilder.newTask()
+            .withType("customType")
+            .inStatus(TaskStatus.ERROR)
+            .withMaxStuckTime(ZonedDateTime.now().plusDays(1))
+            .save()
+            .getTaskId()
+    );
+
+    ResponseEntity<GetTaskDataResponse> dataResponse = badEngineerTemplate()
+        .getForEntity("/v1/twTasks/task/" + task0Id + "/data", GetTaskDataResponse.class);
+
+    assertThat(dataResponse.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+  }
+
+  @SneakyThrows
+  @Test
+  void rightRoleCanViewTaskDataForCustomConfiguration() {
+    final UUID task0Id = transactionsHelper.withTransaction().asNew().call(() ->
+        TaskTestBuilder.newTask()
+            .withType("customType")
+            .inStatus(TaskStatus.ERROR)
+            .withMaxStuckTime(ZonedDateTime.now().plusDays(1))
+            .save()
+            .getTaskId()
+    );
+
+    ResponseEntity<GetTaskDataResponse> dataResponse = goodEngineerTemplate()
+        .getForEntity("/v1/twTasks/task/" + task0Id + "/data", GetTaskDataResponse.class);
+
+    assertThat(dataResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
   }
 
   @Test

--- a/integration-tests/src/test/resources/config/application.yml
+++ b/integration-tests/src/test/resources/config/application.yml
@@ -33,6 +33,13 @@ tw-tasks:
     triggering:
       kafka:
         bootstrap-servers: ${KAFKA_TCP_HOST:localhost}:${KAFKA_TCP_9092}
+    tasks-management:
+      custom:
+        -
+          taskType: "customType"
+          viewTaskDataRoles:
+            - ROLE_DEVEL
+
 
 logging.level.com.transferwise.tasks: DEBUG
 logging.level.kafka: WARN

--- a/integration-tests/src/test/resources/config/application.yml
+++ b/integration-tests/src/test/resources/config/application.yml
@@ -34,10 +34,10 @@ tw-tasks:
       kafka:
         bootstrap-servers: ${KAFKA_TCP_HOST:localhost}:${KAFKA_TCP_9092}
     tasks-management:
-      custom:
+      type-specific:
         -
-          taskType: "customType"
-          viewTaskDataRoles:
+          task-type: "customType"
+          view-task-data-roles:
             - ROLE_DEVEL
 
 

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/TasksProperties.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/TasksProperties.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.Set;
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.experimental.Accessors;
@@ -323,22 +324,29 @@ public class TasksProperties {
   }
 
   @Data
+  @Validated
   public static class TasksManagement {
 
     /**
      * A role for viewing PII data.
      */
+    @NotNull
     private Set<String> viewTaskDataRoles = new HashSet<>(Collections.singletonList("NONEXISTING_ROLE_FOR_TESTING_PURPOSES_ONLY"));
     /**
      * Roles for all other task management endpoints.
      */
+    @NotNull
     private Set<String> roles = new HashSet<>(Collections.singleton("ROLE_DEVEL"));
 
-    private List<CustomTaskManagement> custom = Collections.emptyList();
+    @NotNull
+    private List<TypeSpecificTaskManagement> typeSpecific = Collections.emptyList();
 
     @Data
-    public static class CustomTaskManagement {
+    @Validated
+    public static class TypeSpecificTaskManagement {
+      @NotBlank
       private String taskType;
+      @NotEmpty
       private Set<String> viewTaskDataRoles = new HashSet<>(Collections.singletonList("NONEXISTING_ROLE_FOR_TESTING_PURPOSES_ONLY"));
     }
   }

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/TasksProperties.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/TasksProperties.java
@@ -333,6 +333,14 @@ public class TasksProperties {
      * Roles for all other task management endpoints.
      */
     private Set<String> roles = new HashSet<>(Collections.singleton("ROLE_DEVEL"));
+
+    private List<CustomTaskManagement> custom = Collections.emptyList();
+
+    @Data
+    public static class CustomTaskManagement {
+      private String taskType;
+      private Set<String> viewTaskDataRoles = new HashSet<>(Collections.singletonList("NONEXISTING_ROLE_FOR_TESTING_PURPOSES_ONLY"));
+    }
   }
 
   /**

--- a/tw-tasks-management/build.gradle
+++ b/tw-tasks-management/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     implementation libraries.springTx
     implementation libraries.springContext
     implementation libraries.twContext
+    implementation libraries.javaxAnnotationApi
 
     compileOnly libraries.springWeb
     compileOnly libraries.jakartaValidationApi


### PR DESCRIPTION
## Context

As an engineer, I'd like to be able to set roles required to view a task payload based on the task type.

### Changes

Adds new properties to allow setting roles for individual task types. This is a non-breaking change.

## Checklist
- [X] I have considered the impact of this change and added a [Change Classification](
https://transferwise.atlassian.net/wiki/spaces/EKB/pages/1401189673/Change+Classifications+and+Expectations) Label (`change:standard`, `change:impactful`, `change:emergency`)
- [X] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
