### PR TITLE
We don't check if task is in submitted status, when grabbing, by default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Describes notable changes.
 
+#### 1.27.0 - 2021/04/08
+- We don't check if task is in submitted status, when grabbing, by default.
+  The version check is enough.
+  It can be turned on though via a property, it can be useful for tw-task test suites.
+
 #### 1.26.0 - 2021/03/14
 - Refactoring and optimizing code around metrics.
 - Fixed high CPU usage around `TasksProperties`, due to `@Validated` annotations.

--- a/build.common.gradle
+++ b/build.common.gradle
@@ -118,7 +118,7 @@ test {
     // outputs.upToDateWhen { false }
 
     jvmArgs("-XX:TieredStopAtLevel=1", "-server", "-noverify", "-Djava.security.egd=file:/dev/./urandom", "-XX:+ExplicitGCInvokesConcurrent",
-            "-Xmx768m", "-XX:+HeapDumpOnOutOfMemoryError")
+            "-Xmx1g", "-XX:+HeapDumpOnOutOfMemoryError")
     useJUnitPlatform()
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.26.0
+version=1.27.0
 org.gradle.internal.http.socketTimeout=120000

--- a/integration-tests/src/test/resources/config/application.yml
+++ b/integration-tests/src/test/resources/config/application.yml
@@ -40,7 +40,6 @@ tw-tasks:
           view-task-data-roles:
             - ROLE_DEVEL
 
-
 logging.level.com.transferwise.tasks: DEBUG
 logging.level.kafka: WARN
 logging.level.org.apache.zookeeper: WARN
@@ -57,6 +56,7 @@ tw-incidents:
     enabled: false
 tw-curator:
   zookeeper-connect-string: ${ZOOKEEPER_TCP_HOST:localhost}:${ZOOKEEPER_TCP_2181}
+
 ---
 
 spring:
@@ -74,6 +74,9 @@ testenv:
   zookeeper:
     host: zk-service1
     port: 2181
+tw-tasks:
+  core:
+    assert-status-on-grabbing: true
 
 ---
 

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/TasksProperties.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/TasksProperties.java
@@ -212,6 +212,8 @@ public class TasksProperties {
 
   private boolean checkVersionBeforeGrabbing = false;
 
+  private boolean assertStatusOnGrabbing = false;
+
   /**
    * The additional task buckets, not including the default bucket, that we will process.
    *

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/dao/MySqlTaskDao.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/dao/MySqlTaskDao.java
@@ -98,8 +98,8 @@ public class MySqlTaskDao implements ITaskDao {
   protected String insertTaskDataSql;
   protected String setToBeRetriedSql;
   protected String setToBeRetriedSql1;
+  protected String grabForProcessingWithStatusAssertionSql;
   protected String grabForProcessingSql;
-  protected String grabForProcessingWithoutStatusAssertionSql;
   protected String setStatusSql;
   protected String getStuckTasksSql;
   protected String prepareStuckOnProcessingTaskForResumingSql;
@@ -152,10 +152,10 @@ public class MySqlTaskDao implements ITaskDao {
     setToBeRetriedSql = "update " + taskTable + " set status=?,next_event_time=?,state_time=?,time_updated=?,version=? where id=? and version=?";
     setToBeRetriedSql1 = "update " + taskTable + " set status=?,next_event_time=?"
         + ",processing_tries_count=?,state_time=?,time_updated=?,version=? where id=? and version=?";
-    grabForProcessingSql = "update " + taskTable + " set processing_client_id=?,status=?"
+    grabForProcessingWithStatusAssertionSql = "update " + taskTable + " set processing_client_id=?,status=?"
         + ",processing_start_time=?,next_event_time=?,processing_tries_count=processing_tries_count+1"
         + ",state_time=?,time_updated=?,version=? where id=? and version=? and status=?";
-    grabForProcessingWithoutStatusAssertionSql = "update " + taskTable + " set processing_client_id=?,status=?"
+    grabForProcessingSql = "update " + taskTable + " set processing_client_id=?,status=?"
         + ",processing_start_time=?,next_event_time=?,processing_tries_count=processing_tries_count+1"
         + ",state_time=?,time_updated=?,version=? where id=? and version=?";
     setStatusSql = "update " + taskTable + " set status=?,next_event_time=?,state_time=?,time_updated=?,version=? where id=? and version=?";
@@ -282,10 +282,10 @@ public class MySqlTaskDao implements ITaskDao {
 
     int updatedCount;
     if (tasksProperties.isAssertStatusOnGrabbing()) {
-      updatedCount = jdbcTemplate.update(grabForProcessingSql, args(clientId, TaskStatus.PROCESSING, now,
+      updatedCount = jdbcTemplate.update(grabForProcessingWithStatusAssertionSql, args(clientId, TaskStatus.PROCESSING, now,
           maxProcessingEndTime, now, now, task.getVersion() + 1, task.getId(), task.getVersion(), TaskStatus.SUBMITTED));
     } else {
-      updatedCount = jdbcTemplate.update(grabForProcessingWithoutStatusAssertionSql, args(clientId, TaskStatus.PROCESSING, now,
+      updatedCount = jdbcTemplate.update(grabForProcessingSql, args(clientId, TaskStatus.PROCESSING, now,
           maxProcessingEndTime, now, now, task.getVersion() + 1, task.getId(), task.getVersion()));
     }
 


### PR DESCRIPTION
## Context

Performance on Postgres.

### Changes

We don't check if task is in submitted status, when grabbing, by default.

This was designed as an additional assertion, but version check is already enough.

## Checklist
- [ ] I have considered the impact of this change and added a [Change Classification](
https://transferwise.atlassian.net/wiki/spaces/EKB/pages/1401189673/Change+Classifications+and+Expectations) Label (`change:standard`, `change:impactful`, `change:emergency`)
- [ ] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
