### PR TITLE
Better support for implementing rate-limiting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ references:
     docker:
       - image: arti.tw.ee/circle_openjdk8:latest
         user: circleci
-      - image: circleci/mariadb:10.3
+      - image: circleci/mariadb:10.4
         name: mysql1
         command: "mysqld --ssl=0
             --character-set-server=utf8mb4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 Describes notable changes.
 
 #### 1.28.0 - 2021/05/26
-- Better support for implementing rate-limiting in `ITaskConcurrencyPolicy` implementation.
+- Better support for implementing rate-limiting as an `ITaskConcurrencyPolicy` implementation.
 
 #### 1.27.1 - 2021/05/10
 - Checking of some database transactions state is done only when assertions are enabled.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 Describes notable changes.
 
+#### 1.28.0 - 2021/05/26
+- Better support for implementing rate-limiting in `ITaskConcurrencyPolicy` implementation.
+
 #### 1.27.1 - 2021/05/10
 - Checking of some database transactions state is done only when assertions are enabled.
 

--- a/README.md
+++ b/README.md
@@ -376,13 +376,13 @@ class PayoutTaskConcurrencyPolicy implements ITaskConcurrencyPolicy {
 	private Map<String, AtomicInteger> inProgressCntsPerType = new ConcurrentHashMap<>()
 
 	@Override
-	boolean bookSpaceForTask(BaseTask task) {
+	BookSpaceResponse bookSpace(BaseTask task) {
 		int maxConcurrency = 5
 
 		int cnt = inProgressCnt.incrementAndGet();
 		if (cnt > maxConcurrency) {
 			inProgressCnt.decrementAndGet();
-			return false;
+			return new BookSpaceResponse(false);
 		}
 
 		// Overall concurrency is satisfied, lets check per partner concurrency as well.
@@ -394,14 +394,14 @@ class PayoutTaskConcurrencyPolicy implements ITaskConcurrencyPolicy {
 			if (inProgressCntPerType.incrementAndGet() > maxConcurrencyPerTransferMethod) {
 				inProgressCntPerType.decrementAndGet();
 				inProgressCnt.decrementAndGet();
-				return false;
+				return new BookSpaceResponse(false);
 			}
 		}
-		return true;
+		return new BookSpaceResponse(true);
 	}
 
 	@Override
-	void freeSpaceForTask(BaseTask task) {
+	void freeSpace(BaseTask task) {
 		String transferMethod = getTransferMethod(task);
 		if (transferMethod != null) {
 			if (getOrCreateTypeCounter(transferMethod).decrementAndGet() < 0) {

--- a/README.md
+++ b/README.md
@@ -626,6 +626,10 @@ Basically a copy-paste of current auto-configuration class has to be done. Our c
 
 No out-of-the box copy-paste free support is currently intended for other than Spring-Boot type of applications.
 
+## How-tos
+
+[Rate limiting](docs/rate-limiting.md)
+
 ## License
 Copyright 2019 TransferWise Ltd.
 

--- a/TODO.md
+++ b/TODO.md
@@ -17,17 +17,6 @@ It can be especially useful for test environments.
 8. Rename buckets and processing buckets to shards.
 Much better understandable term. Not many people are aware that in hashmap (where the term bucket is coming from), the shards are called buckets.
 
-10. Try to get rid of KafkaTemplate and use a TwTasks defined Provider interface instead.
-
-11. Consider the need for Tasks' error handlers.
-Currently there is no strong need for it, because this can be done with proper retry policy and task processor combination.
-However error handlers would be cleaner solution. But those error handlers would need their own retries policies and what not,
-and in the end it may not make things cleaner.
-
-13. Move task payload to separate table for better efficiency with default MySQL binlog settings.
-
-14. Add possibility for binary payload.
-
 16. unique_task_keys table should also support taskIds, it currently works only with string keys.
 
 17. Rename property `tw-tasks.zookeeper-connect-string` to `tw-tasks.kafka.zookeeper.connect-string`, because it is only used for Kafka

--- a/demoapp/build.gradle
+++ b/demoapp/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     implementation project(":tw-tasks-incidents-spring-boot-starter")
     implementation project(":tw-tasks-kafka-listener-spring-boot-starter")
     implementation project(":tw-tasks-management-spring-boot-starter")
+    implementation project(":tw-tasks-jobs-spring-boot-starter")
 
     implementation libraries.springBootStarterWeb
     implementation libraries.springBootStarterJdbc

--- a/demoapp/docker/docker-compose.yml
+++ b/demoapp/docker/docker-compose.yml
@@ -61,7 +61,7 @@ services:
 #    --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --transaction-isolation=READ-COMMITTED"
 
   mariadb:
-    image: mariadb:10.3
+    image: mariadb:10.4
     hostname: mysql
     ports:
       - "13307:3306"

--- a/demoapp/src/main/java/com/transferwise/tasks/demoapp/examples/AnnoyingJob.java
+++ b/demoapp/src/main/java/com/transferwise/tasks/demoapp/examples/AnnoyingJob.java
@@ -1,0 +1,24 @@
+package com.transferwise.tasks.demoapp.examples;
+
+import com.transferwise.tasks.domain.ITask;
+import com.transferwise.tasks.impl.jobs.interfaces.IJob;
+import com.transferwise.tasks.impl.jobs.interfaces.IJob.ProcessResult.ResultCode;
+import java.time.ZonedDateTime;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class AnnoyingJob implements IJob {
+
+  @Override
+  public ZonedDateTime getNextRunTime() {
+    return ZonedDateTime.now().plusMinutes(30);
+  }
+
+  @Override
+  public ProcessResult process(ITask task) {
+    log.info("I'm annoying.");
+    return new ProcessResult().setResultCode(ResultCode.SUCCESS);
+  }
+}

--- a/demoapp/src/main/java/com/transferwise/tasks/demoapp/examples/RateLimitingTaskConcurrencyPolicy.java
+++ b/demoapp/src/main/java/com/transferwise/tasks/demoapp/examples/RateLimitingTaskConcurrencyPolicy.java
@@ -1,0 +1,41 @@
+package com.transferwise.tasks.demoapp.examples;
+
+import com.google.common.util.concurrent.RateLimiter;
+import com.transferwise.tasks.domain.IBaseTask;
+import com.transferwise.tasks.handler.SimpleTaskConcurrencyPolicy;
+import com.transferwise.tasks.handler.interfaces.ITaskConcurrencyPolicy;
+import java.time.Instant;
+import lombok.NonNull;
+
+public class RateLimitingTaskConcurrencyPolicy implements ITaskConcurrencyPolicy {
+
+  // Up to 5 tasks in every second
+  private RateLimiter rateLimiter = RateLimiter.create(5);
+
+  // But not more than 3 in parallel
+  private ITaskConcurrencyPolicy concurrencyLimitingPolicy = new SimpleTaskConcurrencyPolicy(3);
+
+  @Override
+  public @NonNull BookSpaceResponse bookSpace(IBaseTask task) {
+    BookSpaceResponse concurrencyLimitingResponse = concurrencyLimitingPolicy.bookSpace(task);
+    if (!concurrencyLimitingResponse.isHasRoom()) {
+      return concurrencyLimitingResponse;
+    }
+
+    if (rateLimiter.tryAcquire()) {
+      return concurrencyLimitingResponse;
+    }
+    concurrencyLimitingPolicy.freeSpace(task);
+
+    // Most optimal would be to set `tryAgainTime` when a new permit becomes available.
+    // Unfortunately Guava's implementation does not expose it's inner method for it, so we just try again after 100 millis.
+    // 100 millis worst case latency here and then is not a problem for us.
+    // There probably is a better rate limiting library.
+    return new BookSpaceResponse(false).setTryAgainTime(Instant.now().plusMillis(100));
+  }
+
+  @Override
+  public void freeSpace(IBaseTask task) {
+    concurrencyLimitingPolicy.freeSpace(task);
+  }
+}

--- a/demoapp/src/main/java/com/transferwise/tasks/demoapp/examples/RateLimitingTaskConcurrencyPolicy.java
+++ b/demoapp/src/main/java/com/transferwise/tasks/demoapp/examples/RateLimitingTaskConcurrencyPolicy.java
@@ -29,7 +29,7 @@ public class RateLimitingTaskConcurrencyPolicy implements ITaskConcurrencyPolicy
 
     // Most optimal would be to set `tryAgainTime` when a new permit becomes available.
     // Unfortunately Guava's implementation does not expose it's inner method for it, so we just try again after 100 millis.
-    // 100 millis worst case latency here and then is not a problem for us.
+    // 100 millis worst case latency here and there is not a problem for us.
     // There probably is a better rate limiting library.
     return new BookSpaceResponse(false).setTryAgainTime(Instant.now().plusMillis(100));
   }

--- a/demoapp/src/main/java/com/transferwise/tasks/demoapp/payout/PayoutProcessingTaskHandlerConfiguration.java
+++ b/demoapp/src/main/java/com/transferwise/tasks/demoapp/payout/PayoutProcessingTaskHandlerConfiguration.java
@@ -52,24 +52,24 @@ public class PayoutProcessingTaskHandlerConfiguration {
       private final AtomicInteger lhvInProgressCnt = new AtomicInteger();
 
       @Override
-      public boolean bookSpaceForTask(IBaseTask task) {
+      public BookSpaceResponse bookSpace(IBaseTask task) {
         if (totalInProgressCnt.incrementAndGet() > 40) {
           totalInProgressCnt.decrementAndGet();
-          return false;
+          return new BookSpaceResponse(false);
         }
 
         if (task.getType().equals(TASK_TYPE_PROCESSING + ".LHV")) {
           if (lhvInProgressCnt.incrementAndGet() > 20) {
             lhvInProgressCnt.decrementAndGet();
             totalInProgressCnt.decrementAndGet();
-            return false;
+            return new BookSpaceResponse(false);
           }
         }
-        return true;
+        return new BookSpaceResponse(true);
       }
 
       @Override
-      public void freeSpaceForTask(IBaseTask task) {
+      public void freeSpace(IBaseTask task) {
         totalInProgressCnt.decrementAndGet();
         if (task.getType().equals(TASK_TYPE_PROCESSING + ".LHV")) {
           lhvInProgressCnt.decrementAndGet();

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -1,0 +1,56 @@
+## Rate-limiting
+
+When you would need to rate-limit the processing of specific tasks, you can implement a specific ITaskConcurrencyPolicy.
+
+But you need to keep attention on following.
+
+`bookSpace` and `freeSpace` methods have to finish as fast as possible. Otherwise, other tasks processing can get delayed. Unless, those rate-limited
+tasks are processed in a completely separate bucket.
+
+`BookSpaceResponse` should contain `tryAgainTime` so the engine knows when it should try again, without resulting to CPU-burn looping.
+
+One example combining both rate limiting and concurrency control is the following.
+
+```java
+package com.transferwise.tasks.demoapp.examples;
+
+import com.google.common.util.concurrent.RateLimiter;
+import com.transferwise.tasks.domain.IBaseTask;
+import com.transferwise.tasks.handler.SimpleTaskConcurrencyPolicy;
+import com.transferwise.tasks.handler.interfaces.ITaskConcurrencyPolicy;
+import java.time.Instant;
+import lombok.NonNull;
+
+public class RateLimitingTaskConcurrencyPolicy implements ITaskConcurrencyPolicy {
+
+  // Up to 5 tasks in every second
+  private RateLimiter rateLimiter = RateLimiter.create(5);
+
+  // But not more than 3 in parallel
+  private ITaskConcurrencyPolicy concurrencyLimitingPolicy = new SimpleTaskConcurrencyPolicy(3);
+
+  @Override
+  public @NonNull BookSpaceResponse bookSpace(IBaseTask task) {
+    BookSpaceResponse concurrencyLimitingResponse = concurrencyLimitingPolicy.bookSpace(task);
+    if (!concurrencyLimitingResponse.isHasRoom()) {
+      return concurrencyLimitingResponse;
+    }
+
+    if (rateLimiter.tryAcquire()) {
+      return concurrencyLimitingResponse;
+    }
+    concurrencyLimitingPolicy.freeSpace(task);
+
+    // Most optimal would be to set `tryAgainTime` when a new permit becomes available.
+    // Unfortunately Guava's implementation does not expose it's inner method for it, so we just try again after 100 millis.
+    // 100 millis worst case latency here and then is not a problem for us.
+    // There probably is a better rate limiting library.
+    return new BookSpaceResponse(false).setTryAgainTime(Instant.now().plusMillis(100));
+  }
+
+  @Override
+  public void freeSpace(IBaseTask task) {
+    concurrencyLimitingPolicy.freeSpace(task);
+  }
+}
+```

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -43,7 +43,7 @@ public class RateLimitingTaskConcurrencyPolicy implements ITaskConcurrencyPolicy
 
     // Most optimal would be to set `tryAgainTime` when a new permit becomes available.
     // Unfortunately Guava's implementation does not expose it's inner method for it, so we just try again after 100 millis.
-    // 100 millis worst case latency here and then is not a problem for us.
+    // 100 millis worst case latency here and there is not a problem for us.
     // There probably is a better rate limiting library.
     return new BookSpaceResponse(false).setTryAgainTime(Instant.now().plusMillis(100));
   }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.27.1
+version=1.28.0
 org.gradle.internal.http.socketTimeout=120000

--- a/integration-tests/src/test/java/com/transferwise/tasks/testapp/TaskDataIntTest.java
+++ b/integration-tests/src/test/java/com/transferwise/tasks/testapp/TaskDataIntTest.java
@@ -137,8 +137,4 @@ public class TaskDataIntTest extends BaseIntTest {
     assertThat(oldData).isEqualTo("");
   }
 
-  @Test
-  void testTransactionalInsert(){
-
-  }
 }

--- a/integration-tests/src/test/java/com/transferwise/tasks/testapp/TaskDataIntTest.java
+++ b/integration-tests/src/test/java/com/transferwise/tasks/testapp/TaskDataIntTest.java
@@ -136,4 +136,9 @@ public class TaskDataIntTest extends BaseIntTest {
 
     assertThat(oldData).isEqualTo("");
   }
+
+  @Test
+  void testTransactionalInsert(){
+
+  }
 }

--- a/integration-tests/src/test/java/com/transferwise/tasks/testapp/TaskProcessingIntTest.java
+++ b/integration-tests/src/test/java/com/transferwise/tasks/testapp/TaskProcessingIntTest.java
@@ -38,7 +38,6 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import lombok.NonNull;
@@ -381,7 +380,7 @@ public class TaskProcessingIntTest extends BaseIntTest {
     transactionsHelper.withTransaction().asNew().call(() ->
         tasksService.addTask(new ITasksService.AddTaskRequest().setType("test"))
     );
-    await().atMost(Duration.ofDays(1)).until(() -> transactionsHelper.withTransaction().asNew().call(() -> {
+    await().until(() -> transactionsHelper.withTransaction().asNew().call(() -> {
       try {
         return testTasksService.getFinishedTasks("test", null).size() == 1;
       } catch (Throwable t) {

--- a/integration-tests/src/test/java/com/transferwise/tasks/testapp/TaskProcessingIntTest.java
+++ b/integration-tests/src/test/java/com/transferwise/tasks/testapp/TaskProcessingIntTest.java
@@ -13,6 +13,7 @@ import com.transferwise.tasks.ITaskDataSerializer;
 import com.transferwise.tasks.ITasksService;
 import com.transferwise.tasks.ITasksService.AddTaskRequest;
 import com.transferwise.tasks.dao.ITaskDao;
+import com.transferwise.tasks.domain.IBaseTask;
 import com.transferwise.tasks.domain.ITask;
 import com.transferwise.tasks.domain.Task;
 import com.transferwise.tasks.domain.TaskStatus;
@@ -21,6 +22,7 @@ import com.transferwise.tasks.handler.SimpleTaskProcessingPolicy;
 import com.transferwise.tasks.handler.interfaces.ISyncTaskProcessor;
 import com.transferwise.tasks.handler.interfaces.ISyncTaskProcessor.ProcessResult;
 import com.transferwise.tasks.handler.interfaces.ISyncTaskProcessor.ProcessResult.ResultCode;
+import com.transferwise.tasks.handler.interfaces.ITaskConcurrencyPolicy;
 import com.transferwise.tasks.handler.interfaces.ITaskProcessingPolicy;
 import com.transferwise.tasks.management.dao.IManagementTaskDao;
 import com.transferwise.tasks.management.dao.IManagementTaskDao.DaoTask1;
@@ -36,7 +38,10 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.mutable.MutableObject;
 import org.junit.jupiter.api.BeforeEach;
@@ -351,6 +356,39 @@ public class TaskProcessingIntTest extends BaseIntTest {
     assertThat(ownerRef.getValue()).isEqualTo("TransferWise");
     assertThat(criticalityRef.getValue()).isEqualTo(Criticality.CRITICAL_PLUS);
     assertThat(deadlineRef.getValue()).isAfter(Instant.now());
+  }
+
+  @Test
+  void taskWithRateLimitingConcurrencyPolicyWillNotHang() {
+    AtomicInteger counter = new AtomicInteger();
+    testTaskHandlerAdapter.setProcessor((ISyncTaskProcessor) task -> new ProcessResult().setResultCode(ResultCode.DONE));
+
+    testTaskHandlerAdapter.setConcurrencyPolicy(new ITaskConcurrencyPolicy() {
+      @Override
+      public @NonNull BookSpaceResponse bookSpace(IBaseTask task) {
+        if (counter.incrementAndGet() < 5) {
+          return new BookSpaceResponse(false).setTryAgainTime(Instant.now().plusMillis(10));
+        }
+        return new BookSpaceResponse(true);
+      }
+
+      @Override
+      public void freeSpace(IBaseTask task) {
+
+      }
+    });
+
+    transactionsHelper.withTransaction().asNew().call(() ->
+        tasksService.addTask(new ITasksService.AddTaskRequest().setType("test"))
+    );
+    await().atMost(Duration.ofDays(1)).until(() -> transactionsHelper.withTransaction().asNew().call(() -> {
+      try {
+        return testTasksService.getFinishedTasks("test", null).size() == 1;
+      } catch (Throwable t) {
+        log.error(t.getMessage(), t);
+      }
+      return false;
+    }));
   }
 
   private int counterSum(String name) {

--- a/integration-tests/src/test/resources/docker-compose.yml
+++ b/integration-tests/src/test/resources/docker-compose.yml
@@ -43,7 +43,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
   mariadb:
-    image: mariadb:10.3
+    image: mariadb:10.4
     ports:
       - "3306"
     environment:

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/handler/SimpleTaskConcurrencyPolicy.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/handler/SimpleTaskConcurrencyPolicy.java
@@ -23,18 +23,18 @@ public class SimpleTaskConcurrencyPolicy implements ITaskConcurrencyPolicy {
   }
 
   @Override
-  public boolean bookSpaceForTask(IBaseTask task) {
+  public BookSpaceResponse bookSpace(IBaseTask task) {
     int cnt = inProgressCnt.incrementAndGet();
     if (cnt > maxConcurrency) {
       inProgressCnt.decrementAndGet();
-      return false;
+      return new BookSpaceResponse(false);
     }
     maxInProgressCnt = Math.max(maxInProgressCnt, cnt);
-    return true;
+    return new BookSpaceResponse(true);
   }
 
   @Override
-  public void freeSpaceForTask(IBaseTask task) {
+  public void freeSpace(IBaseTask task) {
     if (inProgressCnt.decrementAndGet() < 0) {
       throw new IllegalStateException("Counter went below zero. Algorithm error detected.");
     }

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/handler/interfaces/ITaskConcurrencyPolicy.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/handler/interfaces/ITaskConcurrencyPolicy.java
@@ -10,7 +10,7 @@ import lombok.experimental.Accessors;
 public interface ITaskConcurrencyPolicy {
 
   /**
-   * Engine will ask here if we can start processing of this task.
+   * Engine will ask from it if we can start processing of this task.
    */
   @NonNull
   BookSpaceResponse bookSpace(IBaseTask task);
@@ -32,11 +32,11 @@ public interface ITaskConcurrencyPolicy {
     /**
      * If there is no room, when should we check again?
      *
-     * <p>It is only necessary for some kind of rate limiting based policy, where we are returning no-room, even when there may be no tasks
-     * processing
-     * at the same moment. It is not needed for a simple counter based concurrency like `SimpleTaskConcurrencyPolicy` implementation.
+     * <p>It is only necessary for some kind of rate limiting based policy, where we are returning "no-room", even when there may be no tasks
+     * processing at the same moment.
+     * `tryAgainTime` is not needed for a simple counter based concurrency like `SimpleTaskConcurrencyPolicy` implementation.
      *
-     * <p>If you have the case, that you are returning no-room while there is no task getting processed at the same time, and you will leave this
+     * <p>If you have the case, where you are returning no-room while there is no task getting processed at the same time, and you will leave this
      * attribute empty, there is a chance for small (by default 5 seconds) processing pause. So be careful.
      *
      * <p>The trade-off between a small and a large duration is CPU burn vs some latency. Probably best to think how large processing latency you can

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/handler/interfaces/ITaskConcurrencyPolicy.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/handler/interfaces/ITaskConcurrencyPolicy.java
@@ -1,10 +1,55 @@
 package com.transferwise.tasks.handler.interfaces;
 
 import com.transferwise.tasks.domain.IBaseTask;
+import java.time.Instant;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import lombok.experimental.Accessors;
 
 public interface ITaskConcurrencyPolicy {
 
-  boolean bookSpaceForTask(IBaseTask task);
+  /**
+   * Engine will ask here if we can start processing of this task.
+   */
+  @NonNull
+  BookSpaceResponse bookSpace(IBaseTask task);
 
-  void freeSpaceForTask(IBaseTask task);
+  @Data
+  @Accessors(chain = true)
+  @NoArgsConstructor
+  class BookSpaceResponse {
+
+    public BookSpaceResponse(boolean hasRoom) {
+      setHasRoom(hasRoom);
+    }
+
+    /**
+     * Set to true, if you want this task to start getting processed.
+     */
+    private boolean hasRoom;
+
+    /**
+     * If there is no room, when should we check again?
+     *
+     * <p>It is only necessary for some kind of rate limiting based policy, where we are returning no-room, even when there may be no tasks
+     * processing
+     * at the same moment. It is not needed for a simple counter based concurrency like `SimpleTaskConcurrencyPolicy` implementation.
+     *
+     * <p>If you have the case, that you are returning no-room while there is no task getting processed at the same time, and you will leave this
+     * attribute empty, there is a chance for small (by default 5 seconds) processing pause. So be careful.
+     *
+     * <p>The trade-off between a small and a large duration is CPU burn vs some latency. Probably best to think how large processing latency you can
+     * tolerate in worst case.
+     *
+     * <p>It is specifying the worst case, usually as other tasks are constantly getting processed, triggered, finished, the engine will do new
+     * concurrency checks after those anyway.
+     */
+    private Instant tryAgainTime;
+  }
+
+  /**
+   * Engine will call this, after a task processing finished.
+   */
+  void freeSpace(IBaseTask task);
 }


### PR DESCRIPTION
## Context

Engineers are still creating rate limiting in ITaskConcurrencyPolicy. Because
- It feels more natural.
- Rate limiting in transactional (by default) processors can hog database pool connections and thus require larger pool.

However, when implementing rate limiting into ITaskConcurrencyPolicy in current version, the engine can hang or at least create processing pauses.

### Changes

Better support for implementing rate-limiting in `ITaskConcurrencyPolicy` implementation.

Avoid hangs in the processing engine.

## Checklist
- [ ] I have considered the impact of this change and added a [Change Classification](
https://transferwise.atlassian.net/wiki/spaces/EKB/pages/1401189673/Change+Classifications+and+Expectations) Label (`change:standard`, `change:impactful`, `change:emergency`)
- [ ] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
