### PR TITLE
Resolve plugins from the public gradle plugin portal

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,12 +1,3 @@
-pluginManagement {
-    repositories {
-        maven {
-            setUrl("https://arti.tw.ee/artifactory/plugins-release")
-        }
-        mavenLocal()
-    }
-}
-
 rootProject.name = 'tw-tasks-executor'
 
 include 'tw-tasks-core'


### PR DESCRIPTION
Unblock public builds by resolving plugins from the default repository - public gradle plugins portal ([according to the docs](https://docs.gradle.org/current/userguide/plugins.html#sec:custom_plugin_repositories)).