### PR TITLE
Fixing release tagging and pushing it.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       - ubuntu-latest
     env:
       GRADLE_OPTS: "-Djava.security.egd=file:/dev/./urandom -Dorg.gradle.parallel=true"
-      IN_CIRCLE: true
+      IN_CI: true
       MARIADB_TCP_3306: 3306
       MARIADB_TCP_HOST: mysql1
       KAFKA_TCP_9092: 9092

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,8 @@ jobs:
           KAFKA_UNCLEAN_LEADER_ELECTION_ENABLE: "true"
           KAFKA_LEADER_IMBALANCE_CHECK_INTERVAL_SECONDS: 5
     steps:
+      - name: "Install packages"
+        run: apt-get update && apt-get install -y openssh-client git sudo
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: "Gradle cache"
@@ -67,13 +69,6 @@ jobs:
           path: |
             ~/.gradle
           key: gradle-v1-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties', '**/*.gradle*') }}
-      - name: "Bootstrap git config"
-        if: github.ref != 'refs/heads/master'
-        run: |
-          apt-get update && apt-get install -y openssh-client git sudo
-          mkdir -p ~/.ssh
-          ssh-keyscan github.com >> ~/.ssh/known_hosts
-          git config --global user.name "TW GitHub Actions" && git config --global user.email circle@circle.tw.ee
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
       - name: "Tag release"
@@ -113,6 +108,12 @@ jobs:
           name: all-test-reports
           path: all-test-reports.tar.gz
           retention-days: 7
+      - name: "Bootstrap git config"
+        if: github.ref != 'refs/heads/master'
+        run: |
+          mkdir -p ~/.ssh
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          git config --global user.name "TW GitHub Actions" && git config --global user.email circle@circle.tw.ee
       - name: "Tag release"
         if: github.ref == 'refs/heads/master'
         run: GRADLE_USER_HOME=$HOME/.gradle ./gradlew tagRelease --console=plain --no-daemon

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,6 +74,8 @@ jobs:
           mkdir -p ~/.ssh
           ssh-keyscan github.com >> ~/.ssh/known_hosts
           git config --global user.name "TW GitHub Actions" && git config --global user.email circle@circle.tw.ee
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
       - name: "Tag release"
         if: github.ref != 'refs/heads/master'
         run: GRADLE_USER_HOME=$HOME/.gradle ./gradlew tagRelease --console=plain --no-daemon

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
           KAFKA_LEADER_IMBALANCE_CHECK_INTERVAL_SECONDS: 5
     steps:
       - name: "Install packages"
-        run: apt-get update && apt-get install -y git sudo
+        run: apt-get update && apt-get install -y git
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: "Gradle cache"
@@ -69,11 +69,6 @@ jobs:
           path: |
             ~/.gradle
           key: gradle-v1-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties', '**/*.gradle*') }}
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
-      - name: "Tag release"
-        if: github.ref != 'refs/heads/master'
-        run: GRADLE_USER_HOME=$HOME/.gradle ./gradlew tagRelease --console=plain --no-daemon
       - name: "Assemble jar"
         run: GRADLE_USER_HOME=$HOME/.gradle ./gradlew assemble --console=plain --no-daemon
       - name: "Run tests"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
           KAFKA_LEADER_IMBALANCE_CHECK_INTERVAL_SECONDS: 5
     steps:
       - name: "Install packages"
-        run: apt-get update && apt-get install -y openssh-client git sudo
+        run: apt-get update && apt-get install -y git sudo
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: "Gradle cache"
@@ -108,12 +108,6 @@ jobs:
           name: all-test-reports
           path: all-test-reports.tar.gz
           retention-days: 7
-      - name: "Bootstrap git config"
-        if: github.ref != 'refs/heads/master'
-        run: |
-          mkdir -p ~/.ssh
-          ssh-keyscan github.com >> ~/.ssh/known_hosts
-          git config --global user.name "TW GitHub Actions" && git config --global user.email circle@circle.tw.ee
       - name: "Tag release"
         if: github.ref == 'refs/heads/master'
         run: GRADLE_USER_HOME=$HOME/.gradle ./gradlew tagRelease --console=plain --no-daemon

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,9 @@ jobs:
           KAFKA_UNCLEAN_LEADER_ELECTION_ENABLE: "true"
           KAFKA_LEADER_IMBALANCE_CHECK_INTERVAL_SECONDS: 5
     steps:
+      - name: "Tag release"
+        if: github.ref != 'refs/heads/master'
+        run: GRADLE_USER_HOME=$HOME/.gradle ./gradlew tagRelease --console=plain --no-daemon
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: "Assemble jar"
@@ -95,12 +98,6 @@ jobs:
           name: all-test-reports
           path: all-test-reports.tar.gz
           retention-days: 7
-      - name: "Bootstrap git config"
-        if: github.ref == 'refs/heads/master'
-        run: |
-          mkdir -p ~/.ssh
-          ssh-keyscan github.com >> ~/.ssh/known_hosts
-          git config --global user.name "TW GitHub Actions" && git config --global user.email circle@circle.tw.ee
       - name: "Tag release"
         if: github.ref == 'refs/heads/master'
         run: GRADLE_USER_HOME=$HOME/.gradle ./gradlew tagRelease --console=plain --no-daemon

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,19 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+      - name: "Gradle cache"
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle
+          key: gradle-v1-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties', '**/*.gradle*') }}
+      - name: "Bootstrap git config"
+        if: github.ref != 'refs/heads/master'
+        run: |
+          apt-get update && apt-get install -y openssh-client git
+          mkdir -p ~/.ssh
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          git config --global user.name "TW GitHub Actions" && git config --global user.email circle@circle.tw.ee
       - name: "Tag release"
         if: github.ref != 'refs/heads/master'
         run: GRADLE_USER_HOME=$HOME/.gradle ./gradlew tagRelease --console=plain --no-daemon

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,11 +59,11 @@ jobs:
           KAFKA_UNCLEAN_LEADER_ELECTION_ENABLE: "true"
           KAFKA_LEADER_IMBALANCE_CHECK_INTERVAL_SECONDS: 5
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
       - name: "Tag release"
         if: github.ref != 'refs/heads/master'
         run: GRADLE_USER_HOME=$HOME/.gradle ./gradlew tagRelease --console=plain --no-daemon
-      - name: Checkout repository
-        uses: actions/checkout@v2
       - name: "Assemble jar"
         run: GRADLE_USER_HOME=$HOME/.gradle ./gradlew assemble --console=plain --no-daemon
       - name: "Run tests"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
       - name: "Bootstrap git config"
         if: github.ref != 'refs/heads/master'
         run: |
-          apt-get update && apt-get install -y openssh-client git
+          apt-get update && apt-get install -y openssh-client git sudo
           mkdir -p ~/.ssh
           ssh-keyscan github.com >> ~/.ssh/known_hosts
           git config --global user.name "TW GitHub Actions" && git config --global user.email circle@circle.tw.ee

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ task tagRelease {
     }
 }
 
-group = "com.transferwise.common"
+group = "com.transferwise.tasks"
 
 nexusPublishing {
     repositories {

--- a/docs/db-perf-tests.md
+++ b/docs/db-perf-tests.md
@@ -64,11 +64,11 @@ Comment out `@Disabled` annotation in `integration-tests/src/test/java/com/trans
 
 Run
 ```shell
-IN_CIRCLE=true ./gradlew :integration-tests:test --tests "com.transferwise.tasks.demoapp.DemoAppRealTest.dbPerfTest"
+IN_CI=true ./gradlew :integration-tests:test --tests "com.transferwise.tasks.demoapp.DemoAppRealTest.dbPerfTest"
 ```
 
 > This will basically run 1 million tasks through, executing `com.transferwise.tasks.demoapp.DemoAppRealTest.dbPerfTest`.
-> "IN_CIRCLE=true" prevents creating another local docker environment used for other local tests.
+> "IN_CI=true" prevents creating another local docker environment used for other local tests.
 
 >You may want to truncate following tables at the beginning of each test to get more comparable results.
 >```postgresql

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -40,7 +40,7 @@ test {
 }
 
 
-if (!Boolean.parseBoolean(System.getenv('CI'))) {
+if (!Boolean.parseBoolean(System.getenv('IN_CI'))) {
     dockerCompose.isRequiredBy(test)
 }
 


### PR DESCRIPTION
## Context

Zulu container does not have git installed, so the GHA just downloads files over https and not creating .git folder.

That makes Gradle's grgit plugin fail: https://github.com/transferwise/tw-tasks-executor/actions/runs/1634500479

Fixing release tagging.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
