### PR TITLE
In order for tw-tasks to work on Spring 4.x, restored `TransactionSynchronizationAdapter` class.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### 1.32.1 - 2021/01/05
+
+### Fixed
+
+- Spring's 4.x `TransactionSynchronization` does not have default methods implemented.
+  In order for tw-tasks to work on Spring 4.x, restored `TransactionSynchronizationAdapter` class.
+
 #### 1.32.0 - 2021/01/03
 
 ### Changed

--- a/build.gradle
+++ b/build.gradle
@@ -57,3 +57,7 @@ nexusPublishing {
         }
     }
 }
+
+tasks.findByName("initializeSonatypeStagingRepository").setOnlyIf {
+    System.getenv("OSS_SIGNING_KEY")
+}

--- a/build.publish.gradle
+++ b/build.publish.gradle
@@ -61,3 +61,11 @@ publishing {
         }
     }
 }
+
+tasks.findByName("publishMavenJavaPublicationToMavenRepository").setOnlyIf {
+    System.getenv("MAVEN_URL") && System.getenv("MAVEN_USER") && System.getenv("MAVEN_PASSWORD")
+}
+
+tasks.findByName("publishMavenJavaPublicationToSonatypeRepository").setOnlyIf {
+    System.getenv("OSS_SIGNING_KEY")
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.32.0
+version=1.32.1
 org.gradle.internal.http.socketTimeout=120000

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/TasksService.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/TasksService.java
@@ -27,6 +27,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.Ordered;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
@@ -251,7 +252,7 @@ public class TasksService implements ITasksService, GracefulShutdownStrategy {
   }
 
   @RequiredArgsConstructor
-  private class SynchronouslyTriggerTaskTxSyncAdapter implements TransactionSynchronization {
+  private class SynchronouslyTriggerTaskTxSyncAdapter extends TransactionSynchronizationAdapter {
 
     private final BaseTask task;
 
@@ -267,7 +268,7 @@ public class TasksService implements ITasksService, GracefulShutdownStrategy {
   }
 
   @RequiredArgsConstructor
-  private class AsynchronouslyTriggerTaskTxSyncAdapter implements TransactionSynchronization {
+  private class AsynchronouslyTriggerTaskTxSyncAdapter extends TransactionSynchronizationAdapter {
 
     private final IMdcService mdcService;
     private final UnitOfWorkManager unitOfWorkManager;
@@ -306,4 +307,45 @@ public class TasksService implements ITasksService, GracefulShutdownStrategy {
     }
   }
 
+  /**
+   * This allows to work on Spring 4.x as well.
+   *
+   * <p>Spring 4.x does not have default methods in `TransactionSynchronization` interface.</p>
+   */
+  private static class TransactionSynchronizationAdapter implements TransactionSynchronization {
+
+    @Override
+    public int getOrder() {
+      return Ordered.LOWEST_PRECEDENCE;
+    }
+
+    @Override
+    public void suspend() {
+    }
+
+    @Override
+    public void resume() {
+    }
+
+    @Override
+    public void flush() {
+    }
+
+    @Override
+    public void beforeCommit(boolean readOnly) {
+    }
+
+    @Override
+    public void beforeCompletion() {
+    }
+
+    @Override
+    public void afterCommit() {
+    }
+
+
+    @Override
+    public void afterCompletion(int status) {
+    }
+  }
 }


### PR DESCRIPTION
Spring's 4.x `TransactionSynchronization` does not have default methods implemented.

## Context

In order for tw-tasks to work on Spring 4.x, restored `TransactionSynchronizationAdapter` class.

## Checklist
- [x ] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
