### PR TITLE
document upgrade path required because of consumer config change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### 1.33.1 - 2022/04/20
+### Changed
+- Consumer config partition assignment strategy doesn't support RangeAssignor anymore. You need to upgrade to 1.32.0 before 1.33+.
+
 #### 1.33.0 - 2022/04/05
 
 ### Fixed

--- a/demoapp/src/main/resources/application.yml
+++ b/demoapp/src/main/resources/application.yml
@@ -74,7 +74,7 @@ tw-tasks:
     additional-processing-buckets:
       - emails
     environment:
-      previousVersion: "1.21.1"
+      previousVersion: "1.32.0"
     triggering:
       kafka:
         bootstrap-servers: localhost:9092

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.33.0
+version=1.33.1
 org.gradle.internal.http.socketTimeout=120000

--- a/integration-tests/src/test/resources/config/application.yml
+++ b/integration-tests/src/test/resources/config/application.yml
@@ -29,7 +29,7 @@ tw-tasks:
       algorithm: random
       minSize: 0 # Pretty much forcing compression to always happen, so it will be tested through
     environment:
-      previousVersion: "1.21.1"
+      previousVersion: "1.32.0"
     triggering:
       kafka:
         bootstrap-servers: ${KAFKA_TCP_HOST:localhost}:${KAFKA_TCP_9092}

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/EnvironmentValidator.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/EnvironmentValidator.java
@@ -17,7 +17,7 @@ public class EnvironmentValidator implements IEnvironmentValidator {
     }
 
     Semver previousSemver = new Semver(previousVersion);
-    Semver minimumRequiredPreviousSemver = new Semver("1.21.1");
+    Semver minimumRequiredPreviousSemver = new Semver("1.32.0");
 
     if (previousSemver.compareTo(minimumRequiredPreviousSemver) < 0) {
       throw new IllegalStateException("This version requires at least '" + minimumRequiredPreviousSemver + "' to be deployed first.");


### PR DESCRIPTION
## Context

- Forcing upgrade path to go through 1.32.0 as it's the version where consumer partition strategy was supporting both CooperativeStickyAssignor + RangeAssignor, while 1.33.0 supports CooperativeStickyAssignor only

<!-- Why is this PR necessary? If available, include links to a JIRA ticket or other relevant documentation. -->

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
