### PR TITLE
Reverting kafka consumers range assignor changes.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,8 +85,8 @@ jobs:
           key: gradle-v1-${{ matrix.spring_boot_version }}-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties', '**/*.gradle*') }}
       - name: "Assemble jar"
         run: GRADLE_USER_HOME=$HOME/.gradle ./gradlew assemble --console=plain --info --stacktrace
-      ##- name: "Run checks other than tests"
-      ##  run: GRADLE_USER_HOME=$HOME/.gradle ./gradlew -Dspring.profiles.include=continuous-integration check -x test --console=plain --info --stacktrace -Dorg.gradle.parallel=true
+      - name: "Run checks other than tests"
+        run: GRADLE_USER_HOME=$HOME/.gradle ./gradlew -Dspring.profiles.include=continuous-integration check -x test --console=plain --info --stacktrace -Dorg.gradle.parallel=true
       - name: "Run tests"
         # We will not run tests in parallel, so that the test output is easily understandable
         run: GRADLE_USER_HOME=$HOME/.gradle ./gradlew -Dspring.profiles.include=continuous-integration test --console=plain --info --stacktrace -Dorg.gradle.parallel=false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### 1.33.1 - 2022/04/21
+
+### Fixed
+
+* Putting back `ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG, CooperativeStickyAssignor.class.getName() + "," + RangeAssignor.class.getName()`
+for Kafka consumers. Typically, the tw-tasks consumer group is shared with other kafka consumers in a service, so just `CooperativeStickyAssignor`
+would create issues on older kafka-clients.
+
 #### 1.33.0 - 2022/04/05
 
 ### Fixed

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.33.0
+version=1.33.1
 org.gradle.internal.http.socketTimeout=120000

--- a/integration-tests/src/test/java/com/transferwise/tasks/testapp/config/TestConfiguration.java
+++ b/integration-tests/src/test/java/com/transferwise/tasks/testapp/config/TestConfiguration.java
@@ -30,7 +30,6 @@ import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.CooperativeStickyAssignor;
-import org.apache.kafka.clients.consumer.RangeAssignor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/triggering/KafkaTasksExecutionTriggerer.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/triggering/KafkaTasksExecutionTriggerer.java
@@ -462,7 +462,7 @@ public class KafkaTasksExecutionTriggerer implements ITasksExecutionTriggerer, G
     configs.put(ConsumerConfig.RECONNECT_BACKOFF_MAX_MS_CONFIG, "5000");
     configs.put(ConsumerConfig.RECONNECT_BACKOFF_MS_CONFIG, "100");
     configs.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, "10000");
-    configs.put(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG, CooperativeStickyAssignor.class.getName());
+    configs.put(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG, CooperativeStickyAssignor.class.getName() + "," + RangeAssignor.class.getName());
 
     configs.putAll(tasksProperties.getTriggering().getKafka().getProperties());
 

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/utils/InefficientCode.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/utils/InefficientCode.java
@@ -1,10 +1,5 @@
 package com.transferwise.tasks.utils;
 
-import java.lang.annotation.Documented;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-
 import static java.lang.annotation.ElementType.CONSTRUCTOR;
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.LOCAL_VARIABLE;
@@ -13,8 +8,13 @@ import static java.lang.annotation.ElementType.PACKAGE;
 import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.ElementType.TYPE;
 
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
 /**
- * Marker for indicating that the code can be optimized
+ * Marker for indicating that the code can be optimized.
  */
 @Documented
 @Retention(RetentionPolicy.SOURCE)

--- a/tw-tasks-kafka-listener-spring-boot-starter/src/main/java/com/transferwise/tasks/ext/kafkalistener/autoconfigure/SpringKafkaConsumerPropertiesProvider.java
+++ b/tw-tasks-kafka-listener-spring-boot-starter/src/main/java/com/transferwise/tasks/ext/kafkalistener/autoconfigure/SpringKafkaConsumerPropertiesProvider.java
@@ -16,7 +16,7 @@ public class SpringKafkaConsumerPropertiesProvider implements IKafkaListenerCons
   @Override
   public Map<String, Object> getProperties(int shard) {
     var props = kafkaProperties.buildConsumerProperties();
-    props.put(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG, CooperativeStickyAssignor.class.getName());
+    props.put(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG, CooperativeStickyAssignor.class.getName() + "," + RangeAssignor.class.getName());
 
     return props;
   }


### PR DESCRIPTION
## Context

Reverting kafka consumers range assignor changes.

* Putting back `ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG, CooperativeStickyAssignor.class.getName() + "," + RangeAssignor.class.getName()`
for Kafka consumers. Typically, the tw-tasks consumer group is shared with other kafka consumers in a service, so just `CooperativeStickyAssignor`
would create issues on older kafka-clients.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
