### PR TITLE
Range assignor and implicit transactions for task grabbing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### 1.35.0 - 2022/05/12
+
+### Changed
+
+* Using `CooperativeStickyAssignor,RangeAssignor` when it is detected that `kafka-clients` is `3.+`.
+* Task grabbing is using just implicit transactions.
+
 #### 1.34.0 - 2022/04/22
 
 ### Added
 
-* Simple and small `tw-tasks-jobs-test-spring-boot-starter` module to reduce a bit boilerplate in services testing jobs.
+* Simple and small `tw-tasks-jobs-test-spring-boot-starter` module to reduce a bit of boilerplate in services testing jobs.
 
 ### Changed
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.34.0
+version=1.35.0
 org.gradle.internal.http.socketTimeout=120000

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/dao/MySqlTaskDao.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/dao/MySqlTaskDao.java
@@ -275,8 +275,6 @@ public class MySqlTaskDao implements ITaskDao {
     return updatedCount == 1;
   }
 
-  @Override
-  @Transactional(rollbackFor = Exception.class)
   public Task grabForProcessing(BaseTask task, String clientId, Instant maxProcessingEndTime) {
     Timestamp now = Timestamp.from(Instant.now(TwContextClockHolder.getClock()));
 
@@ -404,7 +402,7 @@ public class MySqlTaskDao implements ITaskDao {
   @Transactional(rollbackFor = Exception.class, isolation = Isolation.READ_UNCOMMITTED)
   @MonitoringQuery
   public Map<Pair<TaskStatus, String>, Integer> getStuckTasksCountByStatusAndType(ZonedDateTime age, int maxCount) {
-    Map<Pair<TaskStatus,String>, MutableInt> resultMap = new HashMap<>();
+    Map<Pair<TaskStatus, String>, MutableInt> resultMap = new HashMap<>();
     for (TaskStatus taskStatus : stuckStatuses) {
       jdbcTemplate.query(getStuckTasksCountGroupedSql, args(taskStatus, age, maxCount), rs -> {
         resultMap.computeIfAbsent(Pair.of(taskStatus, rs.getString(1)), k -> new MutableInt(0)).add(rs.getInt(2));

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/triggering/KafkaTasksExecutionTriggerer.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/triggering/KafkaTasksExecutionTriggerer.java
@@ -55,6 +55,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.CooperativeStickyAssignor;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.RangeAssignor;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -468,7 +469,8 @@ public class KafkaTasksExecutionTriggerer implements ITasksExecutionTriggerer, G
       String kafkaClientsVersion = AppInfoParser.getVersion();
       var kafkaClientsSemver = new Semver(kafkaClientsVersion);
       if (kafkaClientsSemver.isGreaterThanOrEqualTo("3.0.0")) {
-        props.put(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG, CooperativeStickyAssignor.class.getName());
+        props.put(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG,
+            CooperativeStickyAssignor.class.getName() + "," + RangeAssignor.class.getName());
       } else {
         log.warn("`kafka-clients:3+` is highly recommended to minimize re-balancing pauses. Current `kafka-clients` version is `{}`.",
             kafkaClientsVersion);

--- a/tw-tasks-kafka-listener-spring-boot-starter/src/main/java/com/transferwise/tasks/ext/kafkalistener/autoconfigure/SpringKafkaConsumerPropertiesProvider.java
+++ b/tw-tasks-kafka-listener-spring-boot-starter/src/main/java/com/transferwise/tasks/ext/kafkalistener/autoconfigure/SpringKafkaConsumerPropertiesProvider.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.CooperativeStickyAssignor;
+import org.apache.kafka.clients.consumer.RangeAssignor;
 import org.apache.kafka.common.utils.AppInfoParser;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
@@ -23,7 +24,8 @@ public class SpringKafkaConsumerPropertiesProvider implements IKafkaListenerCons
     try {
       var kafkaClientsVersion = new Semver(AppInfoParser.getVersion());
       if (kafkaClientsVersion.isGreaterThanOrEqualTo("3.0.0")) {
-        props.put(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG, CooperativeStickyAssignor.class.getName());
+        props.put(ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG,
+            CooperativeStickyAssignor.class.getName() + "," + RangeAssignor.class.getName());
       }
     } catch (Exception e) {
       log.error("Could not understand Kafka client version.", e);


### PR DESCRIPTION
## Context

* Using `CooperativeStickyAssignor,RangeAssignor` when it is detected that `kafka-clients` is `3.+`.
* Task grabbing is using just implicit transactions.

## Checklist
- [ ] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
