### PR TITLE
Avoids duplicate attempts to push a release tag.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,9 +123,6 @@ jobs:
           name: all-test-reports-${{ matrix.spring_boot_version }}
           path: all-test-reports-${{ matrix.spring_boot_version }}.tar.gz
           retention-days: 7
-      - name: "Tag release"
-        if: github.ref == 'refs/heads/master'
-        run: GRADLE_USER_HOME=$HOME/.gradle ./gradlew tagRelease --console=plain --info --stacktrace
 
   build:
     name: "Build and Test"
@@ -133,5 +130,6 @@ jobs:
       - ubuntu-latest
     needs: matrix_build
     steps:
-      - name: "Do something"
-        run: echo 'Matrix build was successful'
+      - name: "Tag release"
+        if: github.ref == 'refs/heads/master'
+        run: GRADLE_USER_HOME=$HOME/.gradle ./gradlew tagRelease --console=plain --info --stacktrace


### PR DESCRIPTION
## Context

Each matrix build was trying to push a release tag. And 2 of them failed.

This PR fixes it by moving release tag pushing to a separate step.

I manually deleted 1.35.0 release tag, so we don't have to bump version.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
