### PR TITLE
Fixes the release tagging.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,6 +130,14 @@ jobs:
       - ubuntu-latest
     needs: matrix_build
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: "Gradle cache"
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle
+          key: gradle-v1-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties', '**/*.gradle*') }}
       - name: "Tag release"
         if: github.ref == 'refs/heads/master'
         run: GRADLE_USER_HOME=$HOME/.gradle ./gradlew tagRelease --console=plain --info --stacktrace


### PR DESCRIPTION
## Context

Fixes the release tagging.

Current build error was:
```
Run GRADLE_USER_HOME=$HOME/.gradle ./gradlew tagRelease --console=plain --info --stacktrace
/home/runner/work/_temp/2e963d29-7b59-[4](https://github.com/transferwise/tw-tasks-executor/runs/6410539272?check_suite_focus=true#step:2:4)4be-88a2-d29a6e9efdee.sh: line 1: ./gradlew: No such file or directory
Error: Process completed with exit code 127.
```

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
