### PR TITLE
AMLEDD-1419 - Fix for NPE on MultiTransactionStatus

### DIFF
--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/processing/TasksProcessingService.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/processing/TasksProcessingService.java
@@ -495,9 +495,13 @@ public class TasksProcessingService implements GracefulShutdownStrategy, ITasksP
                       process.run();
                     }
                     ISyncTaskProcessor.ProcessResult result = resultHolder.getValue();
-                    if (transactionsHelper.isRollbackOnly()) {
-                      log.debug("Task processor for task '{}' has crappy code. Fixing it with a rollback exception.", task.getVersionId());
-                      throw new SyncProcessingRolledbackException(result);
+                    try {
+                      if (transactionsHelper.isRollbackOnly()) {
+                        log.debug("Task processor for task '{}' has crappy code. Fixing it with a rollback exception.", task.getVersionId());
+                        throw new SyncProcessingRolledbackException(result);
+                      }
+                    } catch (NullPointerException e) {
+                      log.debug("transactionsHelper has issues determining if transaction isRollbackOnly", e);
                     }
                     if (result == null || result.getResultCode() == null
                         || result.getResultCode() == ISyncTaskProcessor.ProcessResult.ResultCode.DONE) {


### PR DESCRIPTION
## Context

When integrating TW Tasks for aml-service and testing https://github.com/transferwise/aml-service/pull/1349

we found an issue that was already affecting payout coordinator:
https://github.com/transferwise/payout-coordinator/blob/master/src/main/kotlin/com/transferwise/payoutcoordinator/util/PayoutCoordiantorTransactionsHelper.kt

```
Sep 13 17:10:41.867 aml-service service: main03.eu-central-1.staging.k8stw.com | aml-service-678ffb576c-5n8np | Processing task '0cd71eff-f9b4-4ede-4655-a52c84f9b56a-14' type: 'PROFILE_SCORING' subType: 'ACCOUNT_PURPOSE_UPDATED' failed. java.lang.NullPointerException: Cannot invoke "org.springframework.transaction.TransactionStatus.isRollbackOnly()" because the return value of "org.springframework.data.transaction.MultiTransactionStatus.getMainTransactionStatus()" is null
	at org.springframework.data.transaction.MultiTransactionStatus.isRollbackOnly(MultiTransactionStatus.java:91)
	at com.transferwise.common.baseutils.transactionsmanagement.TransactionsHelper.isRollbackOnly(TransactionsHelper.java:19)
	at com.transferwise.tasks.processing.TasksProcessingService.lambda$processTask$9(TasksProcessingService.java:498)
	at com.transferwise.common.baseutils.transactionsmanagement.TransactionsHelper$Builder.lambda$call$0(TransactionsHelper.java:109)
	at com.transferwise.common.baseutils.ExceptionUtils.doUnchecked(ExceptionUtils.java:14)
	at com.transferwise.common.baseutils.transactionsmanagement.TransactionsHelper$Builder.call(TransactionsHelper.java:94)
	at com.transferwise.tasks.processing.TasksProcessingService.lambda$processTask$13(TasksProcessingService.java:493)
	at com.transferwise.tasks.processing.TasksProcessingService.processWithInterceptors(TasksProcessingService.java:431)
	at com.transferwise.tasks.processing.TasksProcessingService.lambda$processTask$14(TasksProcessingService.java:468)
	at com.transferwise.common.context.TwContext.lambda$execute$3(TwContext.java:284)
	at com.transferwise.common.context.DefaultUnitOfWorkManager$DefaultBuilder.lambda$toContext$0(DefaultUnitOfWorkManager.java:160)
	at com.transferwise.common.context.TwContext.lambda$getWrappedSupplier$2(TwContext.java:256)
	at com.transferwise.common.context.TwContext.executeWithInterceptors(TwContext.java:303)
	at com.transferwise.common.context.TwContext.lambda$executeWithInterceptors$4(TwContext.java:300)
	at com.transferwise.observability.base.internal.tracing.TraceInitializingExecutionInterceptor.intercept(TraceInitializingExecutionInterceptor.java:39)
	at com.transferwise.common.context.TwContext.executeWithInterceptors(TwContext.java:300)
	at com.transferwise.common.context.TwContext.lambda$executeWithInterceptors$4(TwContext.java:300)
	at com.transferwise.common.context.TwContextUniqueEntryPointsLimitingInterceptor.intercept(TwContextUniqueEntryPointsLimitingInterceptor.java:52)
	at com.transferwise.common.context.TwContext.executeWithInterceptors(TwContext.java:300)
	at com.transferwise.common.context.TwContext.lambda$executeWithInterceptors$4(TwContext.java:300)
	at com.transferwise.common.context.MdcRestoringEntryPointInterceptor.intercept(MdcRestoringEntryPointInterceptor.java:18)
	at com.transferwise.common.context.TwContext.executeWithInterceptors(TwContext.java:300)
	at com.transferwise.common.context.TwContext.executeWithInterceptors(TwContext.java:293)
	at com.transferwise.common.context.TwContext.execute(TwContext.java:283)
	at com.transferwise.tasks.processing.TasksProcessingService.processTask(TasksProcessingService.java:442)
	at com.transferwise.tasks.processing.TasksProcessingService.lambda$scheduleTask$4(TasksProcessingService.java:422)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
	at java.base/java.lang.Thread.run(Thread.java:832)
Sep 13 17:10:41.867 aml-service service: main03.eu-central-1.staging.k8stw.com | aml-service-678ffb576c-5n8np | Task '0cd71eff-f9b4-4ede-4655-a52c84f9b56a-14' marked as ERROR.
```

Basically MultiTransactionStatus.getMainTransactionStatus() returns null for ChainedTransactionManager and we have a null pointer exception when calling `transactionsHelper.isRollbackOnly()`

Since this happens regardless of the state of the execution, proposing to skip this check for such cases to avoid NPEs for other services with this configuration.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
