### PR TITLE
ConsistentKafkaConsumer commit optimization changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### 1.36.0 - 2022/10/24
+
+### Changed
+
+* `ConsistentKafkaConsumer` is asynchronously commiting offsets now with an interval, by default once in 5 seconds per partition.
+  Notice that tw-tasks-kafka-listener is deprecated.
+* `ConsistentKafkaConsumer` is doing a synchronous commit, during revoking of partitions.
+  This would make it much less likely that a node getting those partitions assigned will find duplicates.
+
 #### 1.35.0 - 2022/05/12
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,20 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 #### 1.36.0 - 2022/10/24
 
+### Added
+
+* Some initialization logs allowing to understand which lock keys are used.
+
 ### Changed
 
 * `ConsistentKafkaConsumer` is asynchronously commiting offsets now with an interval, by default once in 5 seconds per partition.
   Notice that tw-tasks-kafka-listener is deprecated.
 * `ConsistentKafkaConsumer` is doing a synchronous commit, during revoking of partitions.
   This would make it much less likely that a node getting those partitions assigned will find duplicates.
+
+### Fixed
+
+* Inserting unique key into database is more consistent.
 
 #### 1.35.0 - 2022/05/12
 
@@ -36,8 +44,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 * Putting back `ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG, CooperativeStickyAssignor.class.getName() + "," + RangeAssignor.class.getName()`
-for Kafka consumers. Typically, the tw-tasks consumer group is shared with other kafka consumers in a service, so just `CooperativeStickyAssignor`
-would create issues on older kafka-clients.
+  for Kafka consumers. Typically, the tw-tasks consumer group is shared with other kafka consumers in a service, so just `CooperativeStickyAssignor`
+  would create issues on older kafka-clients.
 
 #### 1.33.0 - 2022/04/05
 

--- a/build.libraries.gradle
+++ b/build.libraries.gradle
@@ -67,5 +67,6 @@ ext {
             janino                          : 'org.codehaus.janino:janino',
             postgresql                      : 'org.postgresql:postgresql',
             mysqlConnectorJava              : 'mysql:mysql-connector-java',
+            logbackClassic                  : "ch.qos.logback:logback-classic",
     ]
 }

--- a/demoapp/src/main/java/com/transferwise/tasks/demoapp/Application.java
+++ b/demoapp/src/main/java/com/transferwise/tasks/demoapp/Application.java
@@ -29,7 +29,7 @@ public class Application {
 
   private static void catchUncaughtExceptions() {
     Thread.setDefaultUncaughtExceptionHandler((t, e) -> {
-      log.error("Uncaught exception occured in '" + t.getId() + "'. Contact developers immediately.", e);
+      log.error("Uncaught exception occurred in '" + t.getId() + "'. Contact developers immediately.", e);
       e.printStackTrace(); // In case logging system is messed up.
     });
   }

--- a/demoapp/src/main/java/com/transferwise/tasks/demoapp/ninjas/CoreKafkaListener.java
+++ b/demoapp/src/main/java/com/transferwise/tasks/demoapp/ninjas/CoreKafkaListener.java
@@ -61,7 +61,6 @@ public class CoreKafkaListener implements GracefulShutdownStrategy {
 
     new ConsistentKafkaConsumer<String>().setTopics(topics)
         .setDelayTimeout(Duration.ofSeconds(5))
-        .setShouldPollPredicate(() -> true)
         .setShouldFinishPredicate(() -> shuttingDown)
         .setKafkaPropertiesSupplier(() -> kafkaConsumerProps)
         .setRecordConsumer((record) -> {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.35.0
+version=1.36.0
 org.gradle.internal.http.socketTimeout=120000

--- a/integration-tests/src/test/java/com/transferwise/tasks/BaseIntTest.java
+++ b/integration-tests/src/test/java/com/transferwise/tasks/BaseIntTest.java
@@ -4,6 +4,7 @@ import com.transferwise.common.baseutils.meters.cache.IMeterCache;
 import com.transferwise.common.baseutils.transactionsmanagement.ITransactionsHelper;
 import com.transferwise.common.context.TwContextClockHolder;
 import com.transferwise.tasks.test.ITestTasksService;
+import com.transferwise.tasks.test.MetricsTestHelper;
 import com.transferwise.tasks.testapp.IResultRegisteringSyncTaskProcessor;
 import com.transferwise.tasks.testapp.TestTaskHandler;
 import com.transferwise.tasks.testapp.config.TestApplication;
@@ -49,6 +50,8 @@ public abstract class BaseIntTest {
   protected MeterRegistry meterRegistry;
   @Autowired
   protected IMeterCache meterCache;
+  @Autowired
+  protected MetricsTestHelper metricsTestHelper;
 
   @Autowired
   void setApplicationContext(ApplicationContext applicationContext) {

--- a/integration-tests/src/test/java/com/transferwise/tasks/test/DefaultMetricsTestHelper.java
+++ b/integration-tests/src/test/java/com/transferwise/tasks/test/DefaultMetricsTestHelper.java
@@ -1,0 +1,26 @@
+package com.transferwise.tasks.test;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DefaultMetricsTestHelper implements MetricsTestHelper {
+
+  @Autowired
+  private MeterRegistry meterRegistry;
+
+  @Override
+  public double getCount(String name, String... tags) {
+    var counters = meterRegistry.find(name).tags(tags).counters();
+    if (counters.isEmpty()) {
+      return 0d;
+    }
+    if (counters.size() > 1) {
+      throw new IllegalStateException("" + counters.size() + " counters found for '" + name + "'(" + StringUtils.join(tags, ",") + ")");
+    }
+
+    return counters.iterator().next().count();
+  }
+}

--- a/integration-tests/src/test/java/com/transferwise/tasks/test/MetricsTestHelper.java
+++ b/integration-tests/src/test/java/com/transferwise/tasks/test/MetricsTestHelper.java
@@ -1,0 +1,5 @@
+package com.transferwise.tasks.test;
+
+public interface MetricsTestHelper {
+  double getCount(String name, String...tags);
+}

--- a/integration-tests/src/test/resources/config/application.yml
+++ b/integration-tests/src/test/resources/config/application.yml
@@ -40,11 +40,12 @@ tw-tasks:
           view-task-data-roles:
             - ROLE_DEVEL
 
-logging.level.com.transferwise.tasks: DEBUG
-logging.level.com.transferwise.tasks.cleaning.TasksCleaner: INFO
-logging.level.kafka: WARN
-logging.level.org.apache.zookeeper: WARN
-logging.level.com.transferwise.tasks.helpers.kafka.ConsistentKafkaConsumer: INFO
+logging.level:
+  com.transferwise.tasks: DEBUG
+  com.transferwise.tasks.cleaning.TasksCleaner: INFO
+  kafka: WARN
+  org.apache.zookeeper: WARN
+  com.transferwise.tasks.helpers.kafka.ConsistentKafkaConsumer: INFO
 
 tw-graceful-shutdown:
   shutdown-timeout-ms: 1000

--- a/integration-tests/src/test/resources/logback.xml
+++ b/integration-tests/src/test/resources/logback.xml
@@ -5,6 +5,8 @@
         </encoder>
     </appender>
 
+    <logger name="com.transferwise.tasks.helpers.kafka" level="debug" />
+
     <root level="info">
         <appender-ref ref="STDOUT"/>
     </root>

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/cleaning/TasksCleaner.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/cleaning/TasksCleaner.java
@@ -87,6 +87,8 @@ public class TasksCleaner implements ITasksCleaner, GracefulShutdownStrategy {
             log.info("Tasks cleaner stopped.");
           });
     }).build();
+
+    log.info("Tasks cleaner initialized with lock key '{}'.", nodePath);
   }
 
   @EntryPoint

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/health/ClusterWideTasksStateMonitor.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/health/ClusterWideTasksStateMonitor.java
@@ -71,7 +71,7 @@ public class ClusterWideTasksStateMonitor implements ITasksStateMonitor, Gracefu
 
   private List<Object> registeredMetricHandles;
   private Map<String, Object> taskInErrorStateHandles;
-  private Map<Pair<TaskStatus,String>, Object> stuckTasksStateHandles;
+  private Map<Pair<TaskStatus, String>, Object> stuckTasksStateHandles;
 
   private final Lock stateLock = new ReentrantLock();
   private boolean initialized;
@@ -107,6 +107,8 @@ public class ClusterWideTasksStateMonitor implements ITasksStateMonitor, Gracefu
     }).build();
 
     registerLibrary();
+
+    log.info("Cluster-wide tasks state monitor initialized with lock key '{}'.", nodePath);
   }
 
   /**
@@ -257,7 +259,7 @@ public class ClusterWideTasksStateMonitor implements ITasksStateMonitor, Gracefu
       stuckTasksCount.set(stuckTasksCountValue);
     }
 
-    Set<Pair<TaskStatus,String>> stuckTasksByStatusAndType = new HashSet<>();
+    Set<Pair<TaskStatus, String>> stuckTasksByStatusAndType = new HashSet<>();
     stuckTasksCountByStatusAndType.forEach((statusAndType, count) -> {
       stuckTasksByStatusAndType.add(statusAndType);
       AtomicInteger typeCounter = stuckTasksCounts.computeIfAbsent(statusAndType, k -> {
@@ -271,8 +273,8 @@ public class ClusterWideTasksStateMonitor implements ITasksStateMonitor, Gracefu
     });
 
     // make sure that we reset values for the tasks that are not stuck anymore
-    for (Iterator<Pair<TaskStatus,String>> it = stuckTasksCounts.keySet().iterator(); it.hasNext(); ) {
-      Pair<TaskStatus,String> taskStatusAndType = it.next();
+    for (Iterator<Pair<TaskStatus, String>> it = stuckTasksCounts.keySet().iterator(); it.hasNext(); ) {
+      Pair<TaskStatus, String> taskStatusAndType = it.next();
       if (!stuckTasksByStatusAndType.contains(taskStatusAndType)) {
         Object handle = stuckTasksStateHandles.remove(taskStatusAndType);
         registeredMetricHandles.remove(handle);

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/helpers/CoreMetricsTemplate.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/helpers/CoreMetricsTemplate.java
@@ -466,10 +466,11 @@ public class CoreMetricsTemplate implements ICoreMetricsTemplate {
   }
 
   @SuppressWarnings("rawtypes")
-  public void registerKafkaConsumer(Consumer consumer) {
+  public AutoCloseable registerKafkaConsumer(Consumer consumer) {
     // Spring application are setting the tag `spring.id`, so we need to set it as well.
-    new KafkaClientMetrics(consumer, List.of(new ImmutableTag("spring.id", "tw-tasks-" + kafkaClientId.incrementAndGet())))
-        .bindTo(meterCache.getMeterRegistry());
+    var kafkaClientMetrics = new KafkaClientMetrics(consumer, List.of(new ImmutableTag("spring.id", "tw-tasks-" + kafkaClientId.incrementAndGet())));
+    kafkaClientMetrics.bindTo(meterCache.getMeterRegistry());
+    return kafkaClientMetrics;
   }
 
   @SuppressWarnings("rawtypes")

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/helpers/ICoreMetricsTemplate.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/helpers/ICoreMetricsTemplate.java
@@ -119,7 +119,7 @@ public interface ICoreMetricsTemplate {
   Object registerKafkaTasksExecutionTriggererOffsetsCount(String bucketId, Supplier<Number> countSupplier);
 
   @SuppressWarnings("rawtypes")
-  void registerKafkaConsumer(Consumer consumer);
+  AutoCloseable registerKafkaConsumer(Consumer consumer);
 
   @SuppressWarnings("rawtypes")
   void registerKafkaProducer(Producer producer);

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/stucktasks/TasksResumer.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/stucktasks/TasksResumer.java
@@ -133,6 +133,8 @@ public class TasksResumer implements ITasksResumer, GracefulShutdownStrategy {
             log.info("Scheduled tasks executor stopped '" + tasksProperties.getGroupId() + "'.");
           });
     }).build();
+
+    log.info("Tasks resumer initialized with lock key '{}'.", nodePath);
   }
 
   /**

--- a/tw-tasks-kafka-listener-spring-boot-starter/src/main/java/com/transferwise/tasks/ext/kafkalistener/autoconfigure/TwTasksExtKafkaListenerAutoConfiguration.java
+++ b/tw-tasks-kafka-listener-spring-boot-starter/src/main/java/com/transferwise/tasks/ext/kafkalistener/autoconfigure/TwTasksExtKafkaListenerAutoConfiguration.java
@@ -1,6 +1,7 @@
 package com.transferwise.tasks.ext.kafkalistener.autoconfigure;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.transferwise.common.baseutils.meters.cache.IMeterCache;
 import com.transferwise.tasks.ITasksService;
 import com.transferwise.tasks.helpers.kafka.IKafkaListenerConsumerPropertiesProvider;
 import com.transferwise.tasks.helpers.kafka.TwTasksKafkaListenerProperties;
@@ -45,8 +46,8 @@ public class TwTasksExtKafkaListenerAutoConfiguration {
 
   @Bean
   @ConditionalOnMissingBean(IKafkaListenerMetricsTemplate.class)
-  public KafkaListenerMetricsTemplate twTasksKafkaListenerMetricsTemplate() {
-    return new KafkaListenerMetricsTemplate();
+  public KafkaListenerMetricsTemplate twTasksKafkaListenerMetricsTemplate(IMeterCache meterCache) {
+    return new KafkaListenerMetricsTemplate(meterCache);
   }
 
   @Bean

--- a/tw-tasks-kafka-listener/build.gradle
+++ b/tw-tasks-kafka-listener/build.gradle
@@ -20,5 +20,7 @@ dependencies {
     implementation libraries.kafkaClients
     implementation libraries.micrometerCore
 
+    testImplementation libraries.awaitility
     testImplementation libraries.springBootAutoconfigure
+    testImplementation libraries.logbackClassic
 }

--- a/tw-tasks-kafka-listener/src/main/java/com/transferwise/tasks/helpers/kafka/ConsistentKafkaConsumer.java
+++ b/tw-tasks-kafka-listener/src/main/java/com/transferwise/tasks/helpers/kafka/ConsistentKafkaConsumer.java
@@ -1,6 +1,7 @@
 package com.transferwise.tasks.helpers.kafka;
 
 import com.transferwise.common.baseutils.ExceptionUtils;
+import com.transferwise.common.context.TwContextClockHolder;
 import com.transferwise.common.context.UnitOfWorkManager;
 import com.transferwise.tasks.entrypoints.EntryPoint;
 import com.transferwise.tasks.entrypoints.EntryPointsGroups;
@@ -9,20 +10,22 @@ import com.transferwise.tasks.helpers.kafka.meters.IKafkaListenerMetricsTemplate
 import com.transferwise.tasks.triggering.SeekToDurationOnRebalanceListener;
 import com.transferwise.tasks.utils.WaitUtils;
 import java.time.Duration;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.mutable.MutableObject;
-import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.consumer.CommitFailedException;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
@@ -55,81 +58,101 @@ public class ConsistentKafkaConsumer<T> {
   @Setter
   private String autoResetOffsetTo = "-PT1H";
   @Setter
-  private Long shard;
+  private long shard = 0;
+  @Setter
+  private Duration asyncCommitInterval = Duration.ofSeconds(5);
+  @Setter
+  private Duration asyncCommitIntervalJitter = Duration.ofMillis(100);
+
+  private Map<TopicPartition, Long> nextAsyncCommitTimesMs = new ConcurrentHashMap<>();
+  protected Consumer<String, T> consumer;
+  private Map<TopicPartition, Long> committableOffsets = new ConcurrentHashMap<>();
+  private Map<TopicPartition, Long> lastSuccessfullyCommittedOffsets = new ConcurrentHashMap<>();
+  private AutoCloseable consumerMetricsHandle;
+
+  protected void createKafkaConsumer() {
+    Map<String, Object> kafkaConsumerProps = new HashMap<>(kafkaPropertiesSupplier.get());
+    kafkaConsumerProps.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
+
+    if (StringUtils.equalsIgnoreCase(autoResetOffsetTo, "earliest") || StringUtils.equalsIgnoreCase(autoResetOffsetTo, "latest")) {
+      kafkaConsumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, autoResetOffsetTo);
+    }
+
+    consumer = new KafkaConsumer<>(kafkaConsumerProps);
+  }
+
+  protected void registerKafkaConsumerMetrics() {
+    if (kafkaListenerMetricsTemplate != null) {
+      consumerMetricsHandle = kafkaListenerMetricsTemplate.registerKafkaConsumer(consumer, shard);
+    }
+  }
+
+  protected void subscribe() {
+    if (!StringUtils.equalsIgnoreCase(autoResetOffsetTo, "earliest") && !StringUtils.equalsIgnoreCase(autoResetOffsetTo, "latest")) {
+      var autoResetOffsetToDuration = ExceptionUtils.doUnchecked(() -> Duration.parse(autoResetOffsetTo));
+      consumer.subscribe(topics,
+          new CommittingConsumerRebalanceListener(new SeekToDurationOnRebalanceListener(consumer, autoResetOffsetToDuration)));
+    } else {
+      consumer.subscribe(topics, new CommittingConsumerRebalanceListener(null));
+    }
+  }
 
   public void consume() {
-    MutableObject<Consumer<String, T>> consumerHolder = new MutableObject<>();
+    createKafkaConsumer();
     try {
+      registerKafkaConsumerMetrics();
+
+      subscribe();
+
       while (!shouldFinishPredicate.get()) {
         try {
-          if (consumerHolder.getValue() == null) {
-            Map<String, Object> kafkaConsumerProps = new HashMap<>(kafkaPropertiesSupplier.get());
-            kafkaConsumerProps.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
-            Duration autoResetOffsetToDuration = null;
-            if (StringUtils.equalsIgnoreCase(autoResetOffsetTo, "earliest") || StringUtils.equalsIgnoreCase(autoResetOffsetTo, "latest")) {
-              kafkaConsumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, autoResetOffsetTo);
-            } else if (autoResetOffsetTo != null) {
-              autoResetOffsetToDuration = ExceptionUtils.doUnchecked(() -> Duration.parse(autoResetOffsetTo));
-            }
-
-            Consumer<String, T> consumer = new KafkaConsumer<>(kafkaConsumerProps);
-            if (kafkaListenerMetricsTemplate != null) {
-              kafkaListenerMetricsTemplate.registerKafkaConsumer(consumer, shard == null ? 0 : shard);
-            }
-
-            consumerHolder.setValue(consumer);
-            if (autoResetOffsetToDuration == null) {
-              consumer.subscribe(topics);
-            } else {
-              consumer.subscribe(topics, new SeekToDurationOnRebalanceListener(consumerHolder.getValue(), autoResetOffsetToDuration));
-            }
-          }
-
-          boolean shouldPoll = shouldPollPredicate.get();
+          boolean shouldPoll = shouldPollPredicate == null || shouldPollPredicate.get();
           if (!shouldPoll) {
+            // We expect `shouldPollPredicate` itself to avoid CPU burn from this continuous loop.
+            // It is mostly used for tests.
             continue;
           }
 
-          log.debug("Polling from Kafka.");
-          ConsumerRecords<String, T> consumerRecords = consumerHolder.getValue().poll(delayTimeout);
-          handlePolledKafkaMessages(consumerHolder, consumerRecords);
+          var consumerRecords = consumer.poll(delayTimeout);
+
+          handlePolledKafkaMessages(consumerRecords);
+
+          commitAsyncWithLowFrequency();
         } catch (Throwable t) {
           log.error(t.getMessage(), t);
           WaitUtils.sleepQuietly(delayTimeout);
         }
       }
     } finally {
-      close(consumerHolder);
+      unsubscribe();
+      close();
     }
   }
 
   @EntryPoint
-  protected void handlePolledKafkaMessages(MutableObject<Consumer<String, T>> consumerHolder, ConsumerRecords<String, T> consumerRecords) {
+  protected void handlePolledKafkaMessages(ConsumerRecords<String, T> consumerRecords) {
     unitOfWorkManager.createEntryPoint(EntryPointsGroups.TW_TASKS_ENGINE, "handlePolledKafkaMessages").toContext().execute(() -> {
       if (log.isDebugEnabled()) {
         log.debug("Polled " + consumerRecords.count() + " messages from Kafka.");
       }
       if (consumerRecords.isEmpty()) {
         if (log.isDebugEnabled()) {
-          log.debug("No records found for: " + StringUtils.join(consumerHolder.getValue().subscription(), ", "));
+          log.debug("No records found for: " + StringUtils.join(consumer.subscription(), ", "));
         }
         return;
       }
 
-      Map<TopicPartition, Long> committableOffsets = new HashMap<>();
-
-      for (ConsumerRecord<String, T> consumerRecord : consumerRecords) {
+      for (var consumerRecord : consumerRecords) {
         if (log.isDebugEnabled()) {
           log.debug("Received Kafka message from topic '{}', partition {}, offset {}.", consumerRecord.topic(), consumerRecord.partition(),
-              consumerRecord
-                  .offset());
+              consumerRecord.offset());
         }
-
-        TopicPartition topicPartition = new TopicPartition(consumerRecord.topic(), consumerRecord.partition());
 
         while (!shouldFinishPredicate.get()) {
           try {
             recordConsumer.accept(consumerRecord);
+
+            var topicPartition = new TopicPartition(consumerRecord.topic(), consumerRecord.partition());
             committableOffsets.put(topicPartition, consumerRecord.offset() + 1);
             break;
           } catch (Throwable t) {
@@ -140,35 +163,11 @@ public class ConsistentKafkaConsumer<T> {
           }
         }
       }
-
-      if (!committableOffsets.isEmpty()) {
-        Map<TopicPartition, OffsetAndMetadata> commitOffsetMap = committableOffsets.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey,
-            entry -> new OffsetAndMetadata(entry.getValue())));
-
-        if (shouldFinishPredicate.get()) {
-          try {
-            consumerHolder.getValue().commitSync(commitOffsetMap);
-          } catch (Throwable t) {
-            registerCommitException(t);
-          }
-        } else {
-          consumerHolder.getValue().commitAsync(commitOffsetMap, (map, e) -> {
-            if (e == null) {
-              log.debug("Committing offsets completed.");
-            } else {
-              registerCommitException(e);
-            }
-          });
-        }
-      }
     });
   }
 
   protected void registerCommitException(Throwable t) {
     if (t instanceof CommitFailedException || t instanceof RetriableException) { // Topic got rebalanced on shutdown.
-      if (kafkaListenerMetricsTemplate != null) {
-        kafkaListenerMetricsTemplate.registerFailedCommit();
-      }
       log.debug("Committing Kafka offset failed.", t);
       return;
     }
@@ -177,22 +176,157 @@ public class ConsistentKafkaConsumer<T> {
     }
   }
 
-  private void close(MutableObject<Consumer<String, T>> consumerHolder) {
-    if (consumerHolder == null || consumerHolder.getValue() == null) {
+  protected void unsubscribe() {
+    if (consumer == null) {
       return;
+    }
+    try {
+      log.info("Unsubscribing from topics '" + StringUtils.join(consumer.subscription(), ",'") + "'.");
+      consumer.unsubscribe();
+    } catch (Throwable t) {
+      log.error("Unsubscribing Kafka consumer failed.", t);
+    }
+  }
+
+  protected void close() {
+    if (consumerMetricsHandle != null) {
+      try {
+        consumerMetricsHandle.close();
+      } catch (Throwable t) {
+        log.error("Closing Kafka client metrics failed.", t);
+      }
+      consumerMetricsHandle = null;
     }
 
     try {
-      log.info("Unsubscribing from topic '" + StringUtils.join(consumerHolder.getValue().subscription(), ",'") + "'.");
-      consumerHolder.getValue().unsubscribe();
+      consumer.close();
     } catch (Throwable t) {
-      log.error(t.getMessage(), t);
+      log.error("Closing Kafka consumer failed.", t);
     }
+
+    consumer = null;
+
+    lastSuccessfullyCommittedOffsets.clear();
+    committableOffsets.clear();
+    nextAsyncCommitTimesMs.clear();
+  }
+
+  protected void commitSyncOnPartitionRevoke(Collection<TopicPartition> partitions) {
+    Map<TopicPartition, OffsetAndMetadata> offsets = null;
+    for (var partition : partitions) {
+      var offset = committableOffsets.remove(partition);
+      if (offset != null) {
+        var lastSuccessfullyCommittedOffset = lastSuccessfullyCommittedOffsets.remove(partition);
+        if (lastSuccessfullyCommittedOffset == null || !lastSuccessfullyCommittedOffset.equals((offset))) {
+          if (offsets == null) {
+            offsets = new HashMap<>();
+          }
+          offsets.put(partition, new OffsetAndMetadata(offset));
+        }
+      }
+    }
+
+    if (offsets == null) {
+      return;
+    }
+
+    var success = false;
     try {
-      consumerHolder.getValue().close();
+      log.debug("Executing sync commit.");
+      consumer.commitSync(offsets);
+      success = true;
     } catch (Throwable t) {
-      log.error(t.getMessage(), t);
+      registerCommitException(t);
+    } finally {
+      if (kafkaListenerMetricsTemplate != null) {
+        for (var entry : offsets.entrySet()) {
+          var partition = entry.getKey();
+          kafkaListenerMetricsTemplate.registerCommit(shard, partition.topic(), partition.partition(), true, success);
+        }
+      }
     }
-    consumerHolder.setValue(null);
+  }
+
+  protected void commitAsyncWithLowFrequency() {
+    if (asyncCommitInterval == null) {
+      return;
+    }
+
+    for (var entry : committableOffsets.entrySet()) {
+      var partition = entry.getKey();
+      var commitableOffset = committableOffsets.get(partition);
+
+      var nextAsyncCommitTimeMs = nextAsyncCommitTimesMs.get(partition);
+
+      if (nextAsyncCommitTimeMs != null && nextAsyncCommitTimeMs >= TwContextClockHolder.getClock().millis()) {
+        continue;
+      }
+
+      var lastSuccessfullyCommittedOffset = lastSuccessfullyCommittedOffsets.get(partition);
+      if (lastSuccessfullyCommittedOffset != null && lastSuccessfullyCommittedOffset.equals(commitableOffset)) {
+        continue;
+      }
+
+      try {
+        var offsetsToCommit = Collections.singletonMap(partition, new OffsetAndMetadata(commitableOffset));
+
+        try {
+          log.debug("Executing async commit.");
+
+          consumer.commitAsync(offsetsToCommit, (offsets, e) -> {
+            if (e == null) {
+              log.debug("Successfully async-committed offset {} for partition '{}'.", commitableOffset, partition);
+
+              lastSuccessfullyCommittedOffsets.put(partition, commitableOffset);
+            } else {
+              registerCommitException(e);
+            }
+
+            if (kafkaListenerMetricsTemplate != null) {
+              kafkaListenerMetricsTemplate.registerCommit(shard, partition.topic(), partition.partition(), false, e == null);
+            }
+          });
+        } catch (Throwable t) {
+          registerCommitException(t);
+        }
+      } finally {
+        nextAsyncCommitTimesMs.put(partition, TwContextClockHolder.getClock().millis() + asyncCommitInterval.toMillis()
+            + ThreadLocalRandom.current().nextLong(asyncCommitIntervalJitter.toMillis()));
+      }
+    }
+  }
+
+  protected class CommittingConsumerRebalanceListener implements ConsumerRebalanceListener {
+
+    private ConsumerRebalanceListener delegate;
+
+    protected CommittingConsumerRebalanceListener(ConsumerRebalanceListener delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
+      log.info("Partitions revoked for shard {}: '{}'.", shard, partitions);
+
+      commitSyncOnPartitionRevoke(partitions);
+
+      if (delegate != null) {
+        delegate.onPartitionsRevoked(partitions);
+      }
+    }
+
+    @Override
+    public void onPartitionsAssigned(Collection<TopicPartition> partitions) {
+      log.info("Partitions assigned for shard {}: '{}'.", shard, partitions);
+
+      for (var partition : partitions) {
+        lastSuccessfullyCommittedOffsets.remove(partition);
+        committableOffsets.remove(partition);
+      }
+
+      if (delegate != null) {
+        delegate.onPartitionsAssigned(partitions);
+      }
+    }
   }
 }

--- a/tw-tasks-kafka-listener/src/main/java/com/transferwise/tasks/helpers/kafka/messagetotask/CoreKafkaListener.java
+++ b/tw-tasks-kafka-listener/src/main/java/com/transferwise/tasks/helpers/kafka/messagetotask/CoreKafkaListener.java
@@ -94,7 +94,6 @@ public class CoreKafkaListener<T> implements GracefulShutdownStrategy {
     try {
       new ConsistentKafkaConsumer<T>().setTopics(addresses)
           .setDelayTimeout(tasksProperties.getGenericMediumDelay())
-          .setShouldPollPredicate(() -> true)
           .setShouldFinishPredicate(() -> shuttingDown)
           .setKafkaPropertiesSupplier(() -> kafkaConsumerProps)
           .setRecordConsumer(record -> {

--- a/tw-tasks-kafka-listener/src/main/java/com/transferwise/tasks/helpers/kafka/messagetotask/CorruptedMessageRecoveryStrategy.java
+++ b/tw-tasks-kafka-listener/src/main/java/com/transferwise/tasks/helpers/kafka/messagetotask/CorruptedMessageRecoveryStrategy.java
@@ -3,8 +3,8 @@ package com.transferwise.tasks.helpers.kafka.messagetotask;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 
 /**
- * The strategy used to recover corrupted message (the one that cannot be deserialized) while processing it with {@link
- * ResilientKafkaMessageHandler}.
+ * The strategy used to recover corrupted message (the one that cannot be deserialized) while processing it with
+ * {@link ResilientKafkaMessageHandler}.
  */
 public interface CorruptedMessageRecoveryStrategy {
 

--- a/tw-tasks-kafka-listener/src/main/java/com/transferwise/tasks/helpers/kafka/messagetotask/KafkaMessageHandlerFactory.java
+++ b/tw-tasks-kafka-listener/src/main/java/com/transferwise/tasks/helpers/kafka/messagetotask/KafkaMessageHandlerFactory.java
@@ -34,8 +34,8 @@ public class KafkaMessageHandlerFactory {
   }
 
   /**
-   * Creates a resilient handler, every corrupted message will be wrapped and processed separately as described in {@link
-   * CorruptedMessageRecoveryStrategy}.
+   * Creates a resilient handler, every corrupted message will be wrapped and processed separately as described in
+   * {@link CorruptedMessageRecoveryStrategy}.
    *
    * @see ResilientKafkaMessageHandler
    */
@@ -53,8 +53,8 @@ public class KafkaMessageHandlerFactory {
   }
 
   /**
-   * Creates a resilient handler, every corrupted message will be wrapped and processed separately as described in {@link
-   * CorruptedMessageRecoveryStrategy}.
+   * Creates a resilient handler, every corrupted message will be wrapped and processed separately as described in
+   * {@link CorruptedMessageRecoveryStrategy}.
    *
    * @see ResilientKafkaMessageHandler
    */

--- a/tw-tasks-kafka-listener/src/main/java/com/transferwise/tasks/helpers/kafka/meters/IKafkaListenerMetricsTemplate.java
+++ b/tw-tasks-kafka-listener/src/main/java/com/transferwise/tasks/helpers/kafka/meters/IKafkaListenerMetricsTemplate.java
@@ -6,8 +6,8 @@ public interface IKafkaListenerMetricsTemplate {
 
   void registerKafkaCoreMessageProcessing(int shard, String topic);
 
-  void registerFailedCommit();
+  void registerCommit(long shard, String topic, int partition, boolean sync, boolean success);
 
   @SuppressWarnings("rawtypes")
-  void registerKafkaConsumer(Consumer consumer, long shard);
+  AutoCloseable registerKafkaConsumer(Consumer consumer, long shard);
 }

--- a/tw-tasks-kafka-listener/src/main/java/com/transferwise/tasks/helpers/kafka/meters/KafkaListenerMetricsTemplate.java
+++ b/tw-tasks-kafka-listener/src/main/java/com/transferwise/tasks/helpers/kafka/meters/KafkaListenerMetricsTemplate.java
@@ -8,19 +8,24 @@ import io.micrometer.core.instrument.ImmutableTag;
 import io.micrometer.core.instrument.binder.kafka.KafkaClientMetrics;
 import java.util.List;
 import org.apache.kafka.clients.consumer.Consumer;
-import org.springframework.beans.factory.annotation.Autowired;
 
 public class KafkaListenerMetricsTemplate implements IKafkaListenerMetricsTemplate {
 
   private static final String METRIC_CORE_KAFKA_PROCESSED_MESSAGES_COUNT = METRIC_PREFIX + "coreKafka.processedMessagesCount";
-  private static final String METRIC_CONSISTENT_KAFKA_CONSUMER_FAILED_COMMITS_COUNT = METRIC_PREFIX + "consistentKafkaConsumer.failedCommitsCount";
+  private static final String METRIC_CONSISTENT_KAFKA_CONSUMER_COMMITS_COUNT = METRIC_PREFIX + "consistentKafkaConsumer.commitsCount";
 
   private static final String TAG_TOPIC = "topic";
+  private static final String TAG_PARTITION = "partition";
+  private static final String TAG_SUCCESS = "success";
+  private static final String TAG_SYNC = "sync";
   private static final String TAG_SHARD = "shard";
   private static long kafkaConsumerId = 0;
 
-  @Autowired
-  private IMeterCache meterCache;
+  private final IMeterCache meterCache;
+
+  public KafkaListenerMetricsTemplate(IMeterCache meterCache) {
+    this.meterCache = meterCache;
+  }
 
   @Override
   public void registerKafkaCoreMessageProcessing(int shard, String topic) {
@@ -29,19 +34,23 @@ public class KafkaListenerMetricsTemplate implements IKafkaListenerMetricsTempla
   }
 
   @Override
-  public void registerFailedCommit() {
-    meterCache.counter(METRIC_CONSISTENT_KAFKA_CONSUMER_FAILED_COMMITS_COUNT, TagsSet.empty())
+  public void registerCommit(long shard, String topic, int partition, boolean sync, boolean success) {
+    meterCache.counter(METRIC_CONSISTENT_KAFKA_CONSUMER_COMMITS_COUNT, TagsSet.of(TAG_SHARD, String.valueOf(shard), TAG_TOPIC, topic,
+            TAG_PARTITION, String.valueOf(partition), TAG_SUCCESS, String.valueOf(success), TAG_SYNC, String.valueOf(sync)))
         .increment();
   }
 
   @Override
   @SuppressWarnings("rawtypes")
-  public synchronized void registerKafkaConsumer(Consumer consumer, long shard) {
+  public synchronized AutoCloseable registerKafkaConsumer(Consumer consumer, long shard) {
     // Spring application are setting the tag `spring.id`, so we need to set it as well.
 
     // Add specific client id for consumer.
 
-    new KafkaClientMetrics(consumer, List.of(new ImmutableTag("spring.id", "tw-tasks-kafka-listener-" + shard + "-" + (kafkaConsumerId++))))
-        .bindTo(meterCache.getMeterRegistry());
+    var kafkaClientMetrics = new KafkaClientMetrics(consumer,
+        List.of(new ImmutableTag("spring.id", "tw-tasks-kafka-listener-" + shard + "-" + (kafkaConsumerId++))));
+    kafkaClientMetrics.bindTo(meterCache.getMeterRegistry());
+
+    return kafkaClientMetrics;
   }
 }

--- a/tw-tasks-kafka-listener/src/test/java/com/transferwise/tasks/helpers/kafka/ConsistentKafkaConsumerTest.java
+++ b/tw-tasks-kafka-listener/src/test/java/com/transferwise/tasks/helpers/kafka/ConsistentKafkaConsumerTest.java
@@ -1,0 +1,150 @@
+package com.transferwise.tasks.helpers.kafka;
+
+import static org.apache.kafka.common.requests.DeleteAclsResponse.log;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.transferwise.common.baseutils.clock.TestClock;
+import com.transferwise.common.baseutils.meters.cache.MeterCache;
+import com.transferwise.common.context.DefaultUnitOfWorkManager;
+import com.transferwise.common.context.TwContextClockHolder;
+import com.transferwise.tasks.helpers.kafka.meters.KafkaListenerMetricsTemplate;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import lombok.SneakyThrows;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.MockConsumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.Test;
+
+public class ConsistentKafkaConsumerTest {
+
+  private MockConsumer<String, String> mockConsumer;
+
+  @Test
+  @SneakyThrows
+  void testCommitLogic() {
+    var testClock = new TestClock();
+    TwContextClockHolder.setClock(testClock);
+
+    final var meterRegistry = new SimpleMeterRegistry();
+    final var meterCache = new MeterCache(meterRegistry);
+    final var unitOfWorkManager = new DefaultUnitOfWorkManager(meterCache);
+    final var shouldFinish = new AtomicBoolean();
+    final var kafkaListenerMetricsTemplate = new KafkaListenerMetricsTemplate(meterCache);
+
+    final var testTopic = "TestTopic";
+    final var partition0 = new TopicPartition(testTopic, 0);
+    final var processedRecordsCount = new AtomicInteger();
+
+    // MockConsumer does not seem to support rebalance listeners.
+    // So we can not test sync commit metrics here.
+
+    mockConsumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST) {
+      // We are creating some delay, to reduce the spam of logs form the test.
+      @Override
+      public synchronized ConsumerRecords<String, String> poll(final Duration timeout) {
+        long startTimeMs = System.currentTimeMillis();
+        while (true) {
+          var records = super.poll(timeout);
+          if (!records.isEmpty()) {
+            return records;
+          }
+          if (System.currentTimeMillis() - startTimeMs > timeout.toMillis()) {
+            return records;
+          }
+        }
+      }
+    };
+
+    mockConsumer.updatePartitions(testTopic, List.of(new PartitionInfo(testTopic, 1, null, null, null)));
+
+    mockConsumer.schedulePollTask(() -> mockConsumer.rebalance(Collections.singletonList(new TopicPartition(testTopic, 0))));
+    mockConsumer.schedulePollTask(() -> mockConsumer.addRecord(new ConsumerRecord<>(testTopic, 0, 0, "testKey", "testValue0")));
+
+    HashMap<TopicPartition, Long> startOffsets = new HashMap<>();
+    TopicPartition tp = new TopicPartition(testTopic, 0);
+    startOffsets.put(tp, 0L);
+    mockConsumer.updateBeginningOffsets(startOffsets);
+
+    var consistentConsumer = new MockedConsistentKafkaConsumer()
+        .setTopics(Collections.singletonList(testTopic))
+        .setUnitOfWorkManager(unitOfWorkManager)
+        .setShouldFinishPredicate(() -> shouldFinish.get())
+        .setAutoResetOffsetTo("earliest")
+        .setAsyncCommitInterval(Duration.ofSeconds(4))
+        .setDelayTimeout(Duration.ofMillis(100))
+        .setKafkaListenerMetricsTemplate(kafkaListenerMetricsTemplate)
+        .setRecordConsumer(consumerRecord -> {
+          log.info("Received message '{}'.", consumerRecord.value());
+          processedRecordsCount.incrementAndGet();
+        });
+
+    Thread consumerThread = new Thread(consistentConsumer::consume);
+    consumerThread.start();
+
+    await().until(() -> {
+          var offsetAndMetaData = mockConsumer.committed(Set.of(partition0)).get(partition0);
+          return offsetAndMetaData != null && offsetAndMetaData.offset() == 1;
+        }
+    );
+
+    testClock.tick(Duration.ofSeconds(5));
+    mockConsumer.schedulePollTask(() -> mockConsumer.addRecord(new ConsumerRecord<>(testTopic, 0, 1, "testKey", "testValue1")));
+
+    await().until(() -> {
+          var offsetAndMetaData = mockConsumer.committed(Set.of(partition0)).get(partition0);
+          return offsetAndMetaData != null && offsetAndMetaData.offset() == 2;
+        }
+    );
+
+    mockConsumer.commitSync(Map.of(partition0, new OffsetAndMetadata(1)));
+    assertEquals(1, mockConsumer.committed(Set.of(partition0)).get(partition0).offset());
+
+    testClock.tick(Duration.ofSeconds(5));
+    consistentConsumer.commitAsyncWithLowFrequency();
+
+    // If lastCommittedOffset did not change, we will not commit
+    assertEquals(1, mockConsumer.committed(Set.of(partition0)).get(partition0).offset());
+
+    mockConsumer.schedulePollTask(() -> mockConsumer.addRecord(new ConsumerRecord<>(testTopic, 0, 2, "testKey", "testValue2")));
+
+    await().until(() -> {
+          var offsetAndMetaData = mockConsumer.committed(Set.of(partition0)).get(partition0);
+          return offsetAndMetaData != null && offsetAndMetaData.offset() == 3;
+        }
+    );
+
+    mockConsumer.schedulePollTask(() -> mockConsumer.addRecord(new ConsumerRecord<>(testTopic, 0, 3, "testKey", "testValue3")));
+    await().until(() -> processedRecordsCount.get() == 4);
+
+    shouldFinish.set(true);
+    consumerThread.join();
+
+    var asyncCommitsCounter = meterRegistry.find("twTasks.consistentKafkaConsumer.commitsCount")
+        .tags("shard", "0", "topic", testTopic, "partition", "0", "sync", "false", "success", "true").counter();
+
+    var asyncCommitsCount = asyncCommitsCounter == null ? 0 : asyncCommitsCounter.count();
+    assertTrue(asyncCommitsCount >= 3);
+  }
+
+  private class MockedConsistentKafkaConsumer extends ConsistentKafkaConsumer<String> {
+
+    protected void createKafkaConsumer() {
+      consumer = mockConsumer;
+    }
+  }
+
+}

--- a/tw-tasks-kafka-listener/src/test/resources/logback.xml
+++ b/tw-tasks-kafka-listener/src/test/resources/logback.xml
@@ -1,0 +1,14 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{50} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="com.transferwise.tasks.helpers.kafka" level="debug"/>
+
+  <root level="info">
+    <appender-ref ref="STDOUT"/>
+    <appender-ref ref="TEST"/>
+  </root>
+</configuration>


### PR DESCRIPTION
## Context

* `ConsistentKafkaConsumer` is asynchronously commiting offsets now with an interval, by default once in 5 seconds per partition.
  Notice that tw-tasks-kafka-listener is deprecated.
* `ConsistentKafkaConsumer` is doing a synchronous commit, during revoking of partitions.
  This would make it much less likely that a node getting those partitions assigned will find duplicates.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
