### PR TITLE
Fixing a small typo in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ public class SampleCronRegistrar {
 		/*
 		 * This is fast no-OP when task with same UUID is already present.
 		 * We set runAfterTime value, so all nodes will have time to get SampleCronTaskHandler released.
-		 * Otherwise there is a chance that the task goes immediately to ERROR state, because the node choosed for execution
+		 * Otherwise there is a chance that the task goes immediately to ERROR state, because the node chosen for execution
 		 * does not have the handler released yet.
 		 */
 		tasksService.addTask(new ITasksService.AddTaskRequest()


### PR DESCRIPTION
## Context

Fixing a small typo in the readme, in a comment in an init method in the example for cluster wide periodic jobs

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
