### PR TITLE
Spring Boot 2.7 compatibility and sync commits for tasks triggerer on partitions revoking.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,9 +22,9 @@ jobs:
       max-parallel: 100
       matrix:
         spring_boot_version:
-          - 2.6.5
-          - 2.5.11
-          - 2.4.13
+          - 2.7.5
+          - 2.6.13
+          - 2.5.14
     env:
       SPRING_BOOT_VERSION: ${{ matrix.spring_boot_version }}
       GRADLE_OPTS: "-Djava.security.egd=file:/dev/./urandom -Dorg.gradle.parallel=true"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -130,6 +130,12 @@ jobs:
       - ubuntu-latest
     needs: matrix_build
     steps:
+      # Needed hacks to properly fail the build when one matrix build fails.
+      - name: Do something so that GHA is happy
+        run: echo "Be happy!"
+      - name: Verify matrix jobs succeeded
+        if: ${{ needs.matrix_build.result != 'success' }}
+        run: exit 1
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: "Gradle cache"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * Removing support for Spring Boot 2.4
 
+### Removed
+
+* Metric `kafkaTasksExecutionTriggerer.failedCommitsCount` was removed.
+  `kafkaTasksExecutionTriggerer.commitsCount` got `sync` and `success` tags.
+
 #### 1.36.0 - 2022/10/24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### 1.37.0 - 2022/11/17
+
+### Changed
+
+* Tasks' triggers' offset is committed synchronously, when partitions are revoked.
+
+* Reworked paranoid tasks cleaner to work with latest mariadb drivers.
+
+* Made it compatible with Spring Boot 2.7
+
+* Removing support for Spring Boot 2.4
+
 #### 1.36.0 - 2022/10/24
 
 ### Added

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*    @transferwise/central-sre
+*    @transferwise/application-engineering

--- a/build.common.gradle
+++ b/build.common.gradle
@@ -126,7 +126,7 @@ test {
     // When you want to rerun tests without any changes made
     // outputs.upToDateWhen { false }
 
-    jvmArgs("-server", "-noverify", "-Djava.security.egd=file:/dev/./urandom", "-XX:+ExplicitGCInvokesConcurrent",
+    jvmArgs("-server", "-Djava.security.egd=file:/dev/./urandom", "-XX:+ExplicitGCInvokesConcurrent",
             "-Xmx1g", "-XX:+HeapDumpOnOutOfMemoryError")
     useJUnitPlatform()
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("org.springframework.boot:spring-boot-gradle-plugin:${System.getenv("SPRING_BOOT_VERSION") ?: '2.5.11'}")
+        classpath("org.springframework.boot:spring-boot-gradle-plugin:${System.getenv("SPRING_BOOT_VERSION") ?: '2.7.5'}")
     }
 }
 

--- a/build.libraries.gradle
+++ b/build.libraries.gradle
@@ -1,29 +1,31 @@
 ext {
     twContextVersion = "0.11.1"
     twLeaderSelectorVersion = "1.6.0"
+    springBootVersion = "${System.getenv("SPRING_BOOT_VERSION") ?: '2.7.5'}"
+
     libraries = [
             // version defined
             awaitility                      : 'org.awaitility:awaitility:4.2.0',
-            gafferJta                       : 'com.transferwise.common:tw-gaffer-jta:1.4.0',
-            apacheCuratorRecipies           : "org.apache.curator:curator-recipes:5.2.1",
+            gafferJta                       : 'com.transferwise.common:tw-gaffer-jta:1.5.0',
+            apacheCuratorRecipies           : "org.apache.curator:curator-recipes:5.4.0",
             apacheCommonsCollections        : "org.apache.commons:commons-collections4:4.4",
             commonsIo                       : "commons-io:commons-io:2.11.0",
             guava                           : "com.google.guava:guava:31.1-jre",
-            newRelic                        : "com.newrelic.agent.java:newrelic-api:7.6.0",
+            newRelic                        : "com.newrelic.agent.java:newrelic-api:7.11.1",
             semver4j                        : "com.vdurmont:semver4j:3.1.0",
             spotbugsAnnotations             : "com.github.spotbugs:spotbugs-annotations:${spotbugs.toolVersion.get()}",
-            springBootDependencies          : "org.springframework.boot:spring-boot-dependencies:${System.getenv("SPRING_BOOT_VERSION") ?: '2.5.11'}",
-            twGracefulShutdown              : "com.transferwise.common:tw-graceful-shutdown:2.3.0",
-            twGracefulShutdownIntefaces     : "com.transferwise.common:tw-graceful-shutdown-interfaces:2.3.0",
+            springBootDependencies          : "org.springframework.boot:spring-boot-dependencies:$springBootVersion",
+            twGracefulShutdown              : "com.transferwise.common:tw-graceful-shutdown:2.8.0",
+            twGracefulShutdownIntefaces     : "com.transferwise.common:tw-graceful-shutdown-interfaces:2.8.0",
             twContext                       : "com.transferwise.common:tw-context:${twContextVersion}",
             twContextStarter                : "com.transferwise.common:tw-context-starter:${twContextVersion}",
             twIncidents                     : 'com.transferwise.common:tw-incidents:1.1.1',
             twLeaderSelector                : "com.transferwise.common:tw-leader-selector:${twLeaderSelectorVersion}",
             twLeaderSelectorStarter         : "com.transferwise.common:tw-leader-selector-starter:${twLeaderSelectorVersion}",
-            twBaseUtils                     : "com.transferwise.common:tw-base-utils:1.7.1",
+            twBaseUtils                     : "com.transferwise.common:tw-base-utils:1.8.1",
             twEntryPointsStarter            : 'com.transferwise.common:tw-entrypoints-starter:2.7.1',
-            lubenZstd                       : 'com.github.luben:zstd-jni:1.5.0-2',
-            lz4Java                         : 'org.lz4:lz4-java:1.7.1',
+            lubenZstd                       : 'com.github.luben:zstd-jni:1.5.2-5',
+            lz4Java                         : 'org.lz4:lz4-java:1.8.0',
 
             // versions managed by spring-boot-dependencies platform
             flywayCore                      : "org.flywaydb:flyway-core",

--- a/demoapp/docker/docker-compose.yml
+++ b/demoapp/docker/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - "2181:2181"
     environment:
       ALLOW_ANONYMOUS_LOGIN: "yes"
-      JVMFLAGS: -javaagent:/tmp/fullgc-agent.jar -server -Xms25m -Xmx512m -XX:+UseG1GC -Djava.awt.headless=true -XX:MaxMetaspaceExpansion=2M -XX:+TieredCompilation -XX:+HeapDumpOnOutOfMemoryError -XX:GCHeapFreeLimit=5 -XX:GCTimeLimit=90 -noverify -XX:ReservedCodeCacheSize=256m -Djava.security.egd=file:/dev/./urandom -Dcom.sun.xml.internal.bind.v2.runtime.JAXBContextImpl.fastBoot=true -XX:+AggressiveOpts -XX:+UseFastAccessorMethods -Dcom.sun.xml.internal.bind.v2.bytecode.ClassTailor.noOptimize=true -XX:SoftRefLRUPolicyMSPerMB=5 -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:+ExplicitGCInvokesConcurrentAndUnloadsClasses
+      JVMFLAGS: -javaagent:/tmp/fullgc-agent.jar -server -Xms25m -Xmx512m -XX:+UseG1GC -Djava.awt.headless=true -XX:MaxMetaspaceExpansion=2M -XX:+TieredCompilation -XX:+HeapDumpOnOutOfMemoryError -XX:GCHeapFreeLimit=5 -XX:GCTimeLimit=90 -XX:ReservedCodeCacheSize=256m -Djava.security.egd=file:/dev/./urandom -Dcom.sun.xml.internal.bind.v2.runtime.JAXBContextImpl.fastBoot=true -XX:+AggressiveOpts -XX:+UseFastAccessorMethods -Dcom.sun.xml.internal.bind.v2.bytecode.ClassTailor.noOptimize=true -XX:SoftRefLRUPolicyMSPerMB=5 -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:+ExplicitGCInvokesConcurrentAndUnloadsClasses
     volumes:
       - ./java/fullgc-agent.jar:/tmp/fullgc-agent.jar
   kafka-zk:
@@ -20,7 +20,7 @@ services:
       - "2183:2181"
     environment:
       ALLOW_ANONYMOUS_LOGIN: "yes"
-      JVMFLAGS: -javaagent:/tmp/fullgc-agent.jar -server -Xms25m -Xmx512m -XX:+UseG1GC -Djava.awt.headless=true -XX:MaxMetaspaceExpansion=2M -XX:+TieredCompilation -XX:+HeapDumpOnOutOfMemoryError -XX:GCHeapFreeLimit=5 -XX:GCTimeLimit=90 -noverify -XX:ReservedCodeCacheSize=256m -Djava.security.egd=file:/dev/./urandom -Dcom.sun.xml.internal.bind.v2.runtime.JAXBContextImpl.fastBoot=true -XX:+AggressiveOpts -XX:+UseFastAccessorMethods -Dcom.sun.xml.internal.bind.v2.bytecode.ClassTailor.noOptimize=true -XX:SoftRefLRUPolicyMSPerMB=5 -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:+ExplicitGCInvokesConcurrentAndUnloadsClasses
+      JVMFLAGS: -javaagent:/tmp/fullgc-agent.jar -server -Xms25m -Xmx512m -XX:+UseG1GC -Djava.awt.headless=true -XX:MaxMetaspaceExpansion=2M -XX:+TieredCompilation -XX:+HeapDumpOnOutOfMemoryError -XX:GCHeapFreeLimit=5 -XX:GCTimeLimit=90 -XX:ReservedCodeCacheSize=256m -Djava.security.egd=file:/dev/./urandom -Dcom.sun.xml.internal.bind.v2.runtime.JAXBContextImpl.fastBoot=true -XX:+AggressiveOpts -XX:+UseFastAccessorMethods -Dcom.sun.xml.internal.bind.v2.bytecode.ClassTailor.noOptimize=true -XX:SoftRefLRUPolicyMSPerMB=5 -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:+ExplicitGCInvokesConcurrentAndUnloadsClasses
     volumes:
       - ./java/fullgc-agent.jar:/tmp/fullgc-agent.jar
   kafka:
@@ -45,7 +45,7 @@ services:
       LOG4J_LOGGER_ORG: WARN,STDOUT
       LOG4J_LOGGER_ORG_APACHE_KAFKA: WARN,STDOUT
       LOG4J_LOGGER_KAFKA: WARN,STDOUT
-      KAFKA_JVM_PERFORMANCE_OPTS: -javaagent:/tmp/fullgc-agent.jar -server -Xms25m -Xmx512m -XX:+UseG1GC -Djava.awt.headless=true -XX:MaxMetaspaceExpansion=2M -XX:+TieredCompilation -XX:+HeapDumpOnOutOfMemoryError -XX:GCHeapFreeLimit=5 -XX:GCTimeLimit=90 -noverify -XX:ReservedCodeCacheSize=256m -Djava.security.egd=file:/dev/./urandom -Dcom.sun.xml.internal.bind.v2.runtime.JAXBContextImpl.fastBoot=true -XX:+AggressiveOpts -XX:+UseFastAccessorMethods -Dcom.sun.xml.internal.bind.v2.bytecode.ClassTailor.noOptimize=true -XX:SoftRefLRUPolicyMSPerMB=5 -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:+ExplicitGCInvokesConcurrentAndUnloadsClasses
+      KAFKA_JVM_PERFORMANCE_OPTS: -javaagent:/tmp/fullgc-agent.jar -server -Xms25m -Xmx512m -XX:+UseG1GC -Djava.awt.headless=true -XX:MaxMetaspaceExpansion=2M -XX:+TieredCompilation -XX:+HeapDumpOnOutOfMemoryError -XX:GCHeapFreeLimit=5 -XX:GCTimeLimit=90 -XX:ReservedCodeCacheSize=256m -Djava.security.egd=file:/dev/./urandom -Dcom.sun.xml.internal.bind.v2.runtime.JAXBContextImpl.fastBoot=true -XX:+AggressiveOpts -XX:+UseFastAccessorMethods -Dcom.sun.xml.internal.bind.v2.bytecode.ClassTailor.noOptimize=true -XX:SoftRefLRUPolicyMSPerMB=5 -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:+ExplicitGCInvokesConcurrentAndUnloadsClasses
       KAFKA_CREATE_TOPICS: "payout.succeeded:4:1,twTasks.demoapp.executeTask.default:4:1,twTasks.demoapp.executeTask.email:4:1"
     volumes:
       - ./java/fullgc-agent.jar:/tmp/fullgc-agent.jar

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.36.0
+version=1.37.0
 org.gradle.internal.http.socketTimeout=120000

--- a/integration-tests/src/test/java/com/transferwise/tasks/testapp/dao/TaskDaoIntTest.java
+++ b/integration-tests/src/test/java/com/transferwise/tasks/testapp/dao/TaskDaoIntTest.java
@@ -432,12 +432,13 @@ abstract class TaskDaoIntTest extends BaseIntTest {
     testClock.tick(Duration.ofMinutes(11));
     final DeleteFinishedOldTasksResult result = taskDao.deleteOldTasks(TaskStatus.DONE, Duration.ofMinutes(10), 60);
 
-    assertEquals(117 - 60, taskDao.getTasksCountInStatus(1000, TaskStatus.DONE));
-    assertEquals(117 - 60, getUniqueTaskKeysCount());
-    assertEquals(117 - 60, getTaskDatasCount());
     assertEquals(60, result.getDeletedTasksCount());
     assertEquals(60, result.getDeletedUniqueKeysCount());
     assertEquals(60, result.getDeletedTaskDatasCount());
+
+    assertEquals(117 - 60, taskDao.getTasksCountInStatus(1000, TaskStatus.DONE));
+    assertEquals(117 - 60, getUniqueTaskKeysCount());
+    assertEquals(117 - 60, getTaskDatasCount());
     assertNotNull(result.getFirstDeletedTaskNextEventTime());
 
     final DeleteFinishedOldTasksResult result1 = taskDao.deleteOldTasks(TaskStatus.DONE, Duration.ofMinutes(10), 60);

--- a/integration-tests/src/test/resources/config/application.yml
+++ b/integration-tests/src/test/resources/config/application.yml
@@ -39,6 +39,7 @@ tw-tasks:
           task-type: "customType"
           view-task-data-roles:
             - ROLE_DEVEL
+    triggers-commit-interval: 50ms
 
 logging.level:
   com.transferwise.tasks: DEBUG
@@ -85,7 +86,7 @@ spring:
 
 spring:
   datasource:
-    url: jdbc:mariadb://${MARIADB_TCP_HOST:localhost}:${MARIADB_TCP_3306}/tw-tasks-test?maxAllowedPacket=1073741824&useSSL=false&rewriteBatchStatements=true
+    url: jdbc:mariadb://${MARIADB_TCP_HOST:localhost}:${MARIADB_TCP_3306}/tw-tasks-test?rewriteBatchStatements=false
     username: root
     password: example-password-change-me
   kafka:

--- a/integration-tests/src/test/resources/docker-compose.yml
+++ b/integration-tests/src/test/resources/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - "2181"
     environment:
       ALLOW_ANONYMOUS_LOGIN: "yes"
-      JVMFLAGS: -server -Xms25m -Xmx512m -XX:+UseG1GC -Djava.awt.headless=true -XX:MaxMetaspaceExpansion=2M -XX:+TieredCompilation -XX:+HeapDumpOnOutOfMemoryError -XX:GCHeapFreeLimit=5 -XX:GCTimeLimit=90 -noverify -XX:ReservedCodeCacheSize=256m -Djava.security.egd=file:/dev/./urandom -Dcom.sun.xml.internal.bind.v2.runtime.JAXBContextImpl.fastBoot=true -XX:+AggressiveOpts -XX:+UseFastAccessorMethods -Dcom.sun.xml.internal.bind.v2.bytecode.ClassTailor.noOptimize=true -XX:SoftRefLRUPolicyMSPerMB=5 -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:+ExplicitGCInvokesConcurrentAndUnloadsClasses
+      JVMFLAGS: -server -Xms25m -Xmx512m -XX:+UseG1GC -Djava.awt.headless=true -XX:MaxMetaspaceExpansion=2M -XX:+TieredCompilation -XX:+HeapDumpOnOutOfMemoryError -XX:GCHeapFreeLimit=5 -XX:GCTimeLimit=90 -XX:ReservedCodeCacheSize=256m -Djava.security.egd=file:/dev/./urandom -Dcom.sun.xml.internal.bind.v2.runtime.JAXBContextImpl.fastBoot=true -XX:+AggressiveOpts -XX:+UseFastAccessorMethods -Dcom.sun.xml.internal.bind.v2.bytecode.ClassTailor.noOptimize=true -XX:SoftRefLRUPolicyMSPerMB=5 -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:+ExplicitGCInvokesConcurrentAndUnloadsClasses
   kafka-zk:
     image: bitnami/zookeeper:3.4.14
     hostname: kafka-zk
@@ -15,7 +15,7 @@ services:
       - "2181"
     environment:
       ALLOW_ANONYMOUS_LOGIN: "yes"
-      JVMFLAGS: -server -Xms25m -Xmx512m -XX:+UseG1GC -Djava.awt.headless=true -XX:MaxMetaspaceExpansion=2M -XX:+TieredCompilation -XX:+HeapDumpOnOutOfMemoryError -XX:GCHeapFreeLimit=5 -XX:GCTimeLimit=90 -noverify -XX:ReservedCodeCacheSize=256m -Djava.security.egd=file:/dev/./urandom -Dcom.sun.xml.internal.bind.v2.runtime.JAXBContextImpl.fastBoot=true -XX:+AggressiveOpts -XX:+UseFastAccessorMethods -Dcom.sun.xml.internal.bind.v2.bytecode.ClassTailor.noOptimize=true -XX:SoftRefLRUPolicyMSPerMB=5 -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:+ExplicitGCInvokesConcurrentAndUnloadsClasses
+      JVMFLAGS: -server -Xms25m -Xmx512m -XX:+UseG1GC -Djava.awt.headless=true -XX:MaxMetaspaceExpansion=2M -XX:+TieredCompilation -XX:+HeapDumpOnOutOfMemoryError -XX:GCHeapFreeLimit=5 -XX:GCTimeLimit=90 -XX:ReservedCodeCacheSize=256m -Djava.security.egd=file:/dev/./urandom -Dcom.sun.xml.internal.bind.v2.runtime.JAXBContextImpl.fastBoot=true -XX:+AggressiveOpts -XX:+UseFastAccessorMethods -Dcom.sun.xml.internal.bind.v2.bytecode.ClassTailor.noOptimize=true -XX:SoftRefLRUPolicyMSPerMB=5 -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:+ExplicitGCInvokesConcurrentAndUnloadsClasses
   kafka:
     image: wurstmeister/kafka:2.13-2.6.3
     depends_on:
@@ -39,7 +39,7 @@ services:
       LOG4J_LOGGER_ORG: WARN,STDOUT
       LOG4J_LOGGER_ORG_APACHE_KAFKA: WARN,STDOUT
       LOG4J_LOGGER_KAFKA: WARN,STDOUT
-      KAFKA_JVM_PERFORMANCE_OPTS: -server -Xms25m -Xmx512m -XX:+UseG1GC -Djava.awt.headless=true -XX:MaxMetaspaceExpansion=2M -XX:+TieredCompilation -XX:+HeapDumpOnOutOfMemoryError -XX:GCHeapFreeLimit=5 -XX:GCTimeLimit=90 -noverify -XX:ReservedCodeCacheSize=256m -Djava.security.egd=file:/dev/./urandom -Dcom.sun.xml.internal.bind.v2.runtime.JAXBContextImpl.fastBoot=true -XX:+AggressiveOpts -XX:+UseFastAccessorMethods -Dcom.sun.xml.internal.bind.v2.bytecode.ClassTailor.noOptimize=true -XX:SoftRefLRUPolicyMSPerMB=5 -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:+ExplicitGCInvokesConcurrentAndUnloadsClasses
+      KAFKA_JVM_PERFORMANCE_OPTS: -server -Xms25m -Xmx512m -XX:+UseG1GC -Djava.awt.headless=true -XX:MaxMetaspaceExpansion=2M -XX:+TieredCompilation -XX:+HeapDumpOnOutOfMemoryError -XX:GCHeapFreeLimit=5 -XX:GCTimeLimit=90 -XX:ReservedCodeCacheSize=256m -Djava.security.egd=file:/dev/./urandom -Dcom.sun.xml.internal.bind.v2.runtime.JAXBContextImpl.fastBoot=true -XX:+AggressiveOpts -XX:+UseFastAccessorMethods -Dcom.sun.xml.internal.bind.v2.bytecode.ClassTailor.noOptimize=true -XX:SoftRefLRUPolicyMSPerMB=5 -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:+ExplicitGCInvokesConcurrentAndUnloadsClasses
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
   mariadb:

--- a/tw-tasks-core/build.gradle
+++ b/tw-tasks-core/build.gradle
@@ -32,5 +32,6 @@ dependencies {
     implementation libraries.springBeans
     implementation libraries.springBoot // (used by TwTasksApplicationListener)
     implementation libraries.javaxAnnotationApi // (@PostConstruct, make sure lib can start ioc independent way)
-    //
+
+    testImplementation libraries.logbackClassic
 }

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/TasksProperties.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/TasksProperties.java
@@ -56,6 +56,12 @@ public class TasksProperties {
   @NotNull
   private Duration genericMediumDelay = Duration.ofSeconds(5);
   /**
+   * How often do we async commit Kafka triggers offsets.
+   */
+  @NotNull
+  private Duration triggersCommitInterval = Duration.ofSeconds(5);
+
+  /**
    * By default, how long should we expect a task to remain in any state, before we consider it as stuck.
    *
    * <p>Notice, that it is not used for PROCESSING state, where the maximum time is asked from task handler itself.
@@ -283,7 +289,7 @@ public class TasksProperties {
   /**
    * If true, the task cleaning will also handle those cases consistently where just-to-be deleted tasks may change.
    *
-   * <p>It makes the cleaning process a bit less efficient and it is almost never needed.
+   * <p>It makes the cleaning process a bit less efficient, and it is almost never needed.
    */
   private boolean paranoidTasksCleaning = false;
 

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/dao/MySqlTaskTypesMapper.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/dao/MySqlTaskTypesMapper.java
@@ -7,11 +7,17 @@ public class MySqlTaskTypesMapper implements ITaskSqlMapper {
 
   @Override
   public UUID sqlTaskIdToUuid(Object taskId) {
+    if (taskId == null) {
+      return null;
+    }
     return UuidUtils.toUuid((byte[]) taskId);
   }
 
   @Override
   public Object uuidToSqlTaskId(UUID uuid) {
+    if (uuid == null) {
+      return null;
+    }
     return UuidUtils.toBytes(uuid);
   }
 }

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/dao/PostgresTaskDao.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/dao/PostgresTaskDao.java
@@ -30,6 +30,8 @@ public class PostgresTaskDao extends MySqlTaskDao {
         + "(?,?,?,?,?,?,?,?,?,?,?,?) on conflict do nothing";
     insertUniqueTaskKeySql = "insert into " + uniqueTaskKeyTable + "(task_id,key_hash,key) values"
         + "(?, ?, ?) on conflict (key_hash, key) do nothing";
+
+    lockTasksForDeleteBatchesSql = "select id, version from " + taskTable + " where id in (??) for update skip locked";
   }
 
   @Override

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/helpers/CoreMetricsTemplate.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/helpers/CoreMetricsTemplate.java
@@ -68,8 +68,6 @@ public class CoreMetricsTemplate implements ICoreMetricsTemplate {
   private static final String METRIC_KAFKA_TASKS_EXECUTION_TRIGGERER_RECEIVED_TRIGGERS_COUNT =
       METRIC_PREFIX + "kafkaTasksExecutionTriggerer.receivedTriggersCount";
   private static final String METRIC_KAFKA_TASKS_EXECUTION_TRIGGERER_COMMITS_COUNT = METRIC_PREFIX + "kafkaTasksExecutionTriggerer.commitsCount";
-  private static final String METRIC_KAFKA_TASKS_EXECUTION_TRIGGERER_FAILED_COMMITS_COUNT =
-      METRIC_PREFIX + "kafkaTasksExecutionTriggerer.failedCommitsCount";
   private static final String METRIC_KAFKA_TASKS_EXECUTION_TRIGGERER_OFFSET_ALREADY_COMMITTED =
       METRIC_PREFIX + "kafkaTasksExecutionTriggerer.offsetAlreadyCommitted";
   private static final String METRIC_KAFKA_TASKS_EXECUTION_TRIGGERER_OFFSETS_TO_BE_COMMITED_COUNT =
@@ -99,6 +97,8 @@ public class CoreMetricsTemplate implements ICoreMetricsTemplate {
   private static final String TAG_TO_STATUS = "toStatus";
   private static final String TAG_TASK_STATUS = "taskStatus";
   private static final String TAG_BUCKET_ID = "bucketId";
+  private static final String TAG_SYNC = "sync";
+  private static final String TAG_SUCCESS = "success";
   private static final String TAG_TASK_TYPE = "taskType";
   private static final String TAG_SOURCE = "source";
   private static final String TAG_REASON = "reason";
@@ -327,14 +327,9 @@ public class CoreMetricsTemplate implements ICoreMetricsTemplate {
   }
 
   @Override
-  public void registerKafkaTasksExecutionTriggererCommit(String bucketId) {
-    meterCache.counter(METRIC_KAFKA_TASKS_EXECUTION_TRIGGERER_COMMITS_COUNT, TagsSet.of(TAG_BUCKET_ID, resolveBucketId(bucketId)))
-        .increment();
-  }
-
-  @Override
-  public void registerKafkaTasksExecutionTriggererFailedCommit(String bucketId) {
-    meterCache.counter(METRIC_KAFKA_TASKS_EXECUTION_TRIGGERER_FAILED_COMMITS_COUNT, TagsSet.of(TAG_BUCKET_ID, resolveBucketId(bucketId)))
+  public void registerKafkaTasksExecutionTriggererCommit(String bucketId, boolean sync, boolean success) {
+    meterCache.counter(METRIC_KAFKA_TASKS_EXECUTION_TRIGGERER_COMMITS_COUNT, TagsSet.of(TAG_BUCKET_ID, resolveBucketId(bucketId),
+            TAG_SYNC, String.valueOf(sync), TAG_SUCCESS, String.valueOf(success)))
         .increment();
   }
 

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/helpers/ICoreMetricsTemplate.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/helpers/ICoreMetricsTemplate.java
@@ -74,9 +74,7 @@ public interface ICoreMetricsTemplate {
 
   void registerKafkaTasksExecutionTriggererTriggersReceive(String bucketId);
 
-  void registerKafkaTasksExecutionTriggererCommit(String bucketId);
-
-  void registerKafkaTasksExecutionTriggererFailedCommit(String bucketId);
+  void registerKafkaTasksExecutionTriggererCommit(String bucketId, boolean sync, boolean success);
 
   void registerKafkaTasksExecutionTriggererAlreadyCommitedOffset(String bucketId);
 

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/helpers/executors/ExecutorThreadFactory.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/helpers/executors/ExecutorThreadFactory.java
@@ -12,8 +12,7 @@ public class ExecutorThreadFactory implements ThreadFactory {
   public ExecutorThreadFactory(String groupName) {
     this.groupName = groupName;
 
-    SecurityManager s = System.getSecurityManager();
-    group = (s != null) ? s.getThreadGroup() : Thread.currentThread().getThreadGroup();
+    group = Thread.currentThread().getThreadGroup();
 
   }
 

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/helpers/kafka/NoOpTopicPartitionsManager.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/helpers/kafka/NoOpTopicPartitionsManager.java
@@ -44,7 +44,7 @@ public class NoOpTopicPartitionsManager implements ITopicPartitionsManager {
         DescribeTopicsResult describeTopicsResult = adminClient.describeTopics(Collections.singletonList(topic));
         TopicDescription topicDescription = null;
         try {
-          topicDescription = describeTopicsResult.all().get(COMMANDS_TIMEOUT_S, TimeUnit.SECONDS).get(topic);
+          topicDescription = describeTopicsResult.allTopicNames().get(COMMANDS_TIMEOUT_S, TimeUnit.SECONDS).get(topic);
         } catch (ExecutionException e) {
           if (e.getCause() == null || !(e.getCause() instanceof UnknownTopicOrPartitionException)) {
             throw e;

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/helpers/kafka/NoOpTopicPartitionsManager.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/helpers/kafka/NoOpTopicPartitionsManager.java
@@ -44,7 +44,7 @@ public class NoOpTopicPartitionsManager implements ITopicPartitionsManager {
         DescribeTopicsResult describeTopicsResult = adminClient.describeTopics(Collections.singletonList(topic));
         TopicDescription topicDescription = null;
         try {
-          topicDescription = describeTopicsResult.allTopicNames().get(COMMANDS_TIMEOUT_S, TimeUnit.SECONDS).get(topic);
+          topicDescription = describeTopicsResult.all().get(COMMANDS_TIMEOUT_S, TimeUnit.SECONDS).get(topic);
         } catch (ExecutionException e) {
           if (e.getCause() == null || !(e.getCause() instanceof UnknownTopicOrPartitionException)) {
             throw e;

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/triggering/KafkaTasksExecutionTriggerer.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/triggering/KafkaTasksExecutionTriggerer.java
@@ -385,6 +385,7 @@ public class KafkaTasksExecutionTriggerer implements ITasksExecutionTriggerer, G
             .map(e -> e.getKey() + ":" + e.getValue().offset()).collect(Collectors.joining(", ")));
       }
       consumerBucket.getKafkaConsumer().commitSync(offsetsToCommit);
+      success = true;
     } catch (Throwable t) {
       registerCommitException(bucketId, t);
     } finally {

--- a/tw-tasks-core/src/test/resources/logback.xml
+++ b/tw-tasks-core/src/test/resources/logback.xml
@@ -7,6 +7,5 @@
 
   <root level="info">
     <appender-ref ref="STDOUT"/>
-    <appender-ref ref="TEST"/>
   </root>
 </configuration>

--- a/tw-tasks-core/src/test/resources/logback.xml
+++ b/tw-tasks-core/src/test/resources/logback.xml
@@ -1,0 +1,12 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{50} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="info">
+    <appender-ref ref="STDOUT"/>
+    <appender-ref ref="TEST"/>
+  </root>
+</configuration>

--- a/tw-tasks-kafka-listener/src/test/resources/logback.xml
+++ b/tw-tasks-kafka-listener/src/test/resources/logback.xml
@@ -9,6 +9,5 @@
 
   <root level="info">
     <appender-ref ref="STDOUT"/>
-    <appender-ref ref="TEST"/>
   </root>
 </configuration>


### PR DESCRIPTION
## Context

* Tasks' triggers' offset is committed synchronously, when partitions are revoked.

* Reworked paranoid tasks cleaner to work with latest mariadb drivers.

* Made it compatible with Spring Boot 2.7

* Removing support for Spring Boot 2.4

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
