### PR TITLE
Spring Boot 2.6 will be used to derive default dependencies for the l…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,9 +76,9 @@ jobs:
       - name: "Install packages"
         run: apt-get update && apt-get install -y git
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: "Gradle cache"
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle
@@ -93,7 +93,7 @@ jobs:
       - name: "Test if publishing works"
         run: GRADLE_USER_HOME=$HOME/.gradle ./gradlew publishToMavenLocal --console=plain --info --stacktrace
       - name: "Publish Test Report"
-        uses: mikepenz/action-junit-report@v2
+        uses: mikepenz/action-junit-report@v3
         if: always()
         with:
           check_name: Test Report-(${{ matrix.spring_boot_version }})
@@ -117,7 +117,7 @@ jobs:
           tar -zcvf all-test-reports-${{ matrix.spring_boot_version }}.tar.gz **/build/reports
         if: always()
       - name: "Store test results"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: always()
         with:
           name: all-test-reports-${{ matrix.spring_boot_version }}
@@ -137,9 +137,9 @@ jobs:
         if: ${{ needs.matrix_build.result != 'success' }}
         run: exit 1
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: "Gradle cache"
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.gradle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### 1.37.1 - 2022/11/28
+
+### Changed
+
+* The Spring Boot Version from which the library dependencies are derived, was moved from 2.7 to 2.6.
+  This should give better compatibility, as backward compatibility is usually better than forward one.
+
 #### 1.37.0 - 2022/11/17
 
 ### Changed

--- a/build.libraries.gradle
+++ b/build.libraries.gradle
@@ -1,7 +1,7 @@
 ext {
     twContextVersion = "0.11.1"
     twLeaderSelectorVersion = "1.6.0"
-    springBootVersion = "${System.getenv("SPRING_BOOT_VERSION") ?: '2.7.5'}"
+    springBootVersion = "${System.getenv("SPRING_BOOT_VERSION") ?: '2.6.14'}"
 
     libraries = [
             // version defined

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.37.0
+version=1.37.1
 org.gradle.internal.http.socketTimeout=120000


### PR DESCRIPTION
## Context

Spring Boot 2.6 will be used to derive default dependencies for the library.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
