### PR TITLE
feat: configure trigger topic root

### DIFF
--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/TasksProperties.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/TasksProperties.java
@@ -347,7 +347,7 @@ public class TasksProperties {
       private String bootstrapServers;
 
       @ResolvedValue
-      private String topicName;
+      private String topicPrefix;
 
       /**
        * Allows to override configuration properties for both Kafka Consumers. and Producers.

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/TasksProperties.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/TasksProperties.java
@@ -346,6 +346,9 @@ public class TasksProperties {
       @ResolvedValue
       private String bootstrapServers;
 
+      @ResolvedValue
+      private String topicName;
+
       /**
        * Allows to override configuration properties for both Kafka Consumers. and Producers.
        */

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/triggering/KafkaTasksExecutionTriggerer.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/triggering/KafkaTasksExecutionTriggerer.java
@@ -111,7 +111,7 @@ public class KafkaTasksExecutionTriggerer implements ITasksExecutionTriggerer, G
   @PostConstruct
   public void init() {
     executorService = executorsHelper.newCachedExecutor("ktet");
-    triggerTopic = "twTasks." + tasksProperties.getGroupId() + ".executeTask";
+    triggerTopic = triggerTopicNameRoot();
 
     tasksProcessingService.addTaskTriggeringFinishedListener(taskTriggering -> {
       if (taskTriggering.isSameProcessTrigger()) {
@@ -316,6 +316,15 @@ public class KafkaTasksExecutionTriggerer implements ITasksExecutionTriggerer, G
       // Notice, that now commits will not work anymore. However, that is ok, we prefer to unsubscribe,
       // so other nodes can take the partitions to themselves asap.
       closeKafkaConsumer(consumerBuckets.get(bucketId));
+    }
+  }
+
+  private String triggerTopicNameRoot() {
+    String topic = tasksProperties.getTriggering().getKafka().getTopicName();
+    if (topic != null) {
+      return topic;
+    } else {
+      return "twTasks." + tasksProperties.getGroupId() + ".executeTask";
     }
   }
 

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/triggering/KafkaTasksExecutionTriggerer.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/triggering/KafkaTasksExecutionTriggerer.java
@@ -320,7 +320,7 @@ public class KafkaTasksExecutionTriggerer implements ITasksExecutionTriggerer, G
   }
 
   private String triggerTopicNameRoot() {
-    String topic = tasksProperties.getTriggering().getKafka().getTopicName();
+    String topic = tasksProperties.getTriggering().getKafka().getTopicPrefix();
     if (topic != null) {
       return topic;
     } else {


### PR DESCRIPTION
## Context

The name of the triggering topic is calculated based on the consumer group name of the service.

Problem: we have a service using an ugly name historically `fraud.state.2` and we do not want to make the topic name inherit it :(

## Checklist
- [X] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
