### PR TITLE
Bump all MariaDB 10.4s to 10.6 due to DB deprecation risk

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
       image: azul/zulu-openjdk:11
     services:
       mysql1:
-        image: mariadb:10.4
+        image: mariadb:10.6
         env:
           MYSQL_ROOT_PASSWORD: example-password-change-me
           MYSQL_DATABASE: tw-tasks-test

--- a/demoapp/docker/docker-compose.yml
+++ b/demoapp/docker/docker-compose.yml
@@ -61,7 +61,7 @@ services:
 #    --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --transaction-isolation=READ-COMMITTED"
 
   mariadb:
-    image: mariadb:10.4
+    image: mariadb:10.6
     hostname: mysql
     ports:
       - "13307:3306"

--- a/integration-tests/src/test/resources/docker-compose.yml
+++ b/integration-tests/src/test/resources/docker-compose.yml
@@ -43,7 +43,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
   mariadb:
-    image: mariadb:10.4
+    image: mariadb:10.6
     ports:
       - "3306"
     environment:


### PR DESCRIPTION
## Context

All MariaDB 10.4 containers have to be bumped to 10.6 to eliminate database deprecation risk.

## Checklist
- [X] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
