### PR TITLE
Adding a no-op tw task handler for deprecated lingering tw tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### 1.40.2 - 2023/07/14
+
+### Added
+
+* introduced a new configuration parameter `tw-tasks.core.no-op-task-types` that allows a default no operation task handler to pick up deprecated task types in your service.
+
 #### 1.40.1 - 2023/07/12
 
 ### Fixed

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.40.1
+version=1.40.2
 org.gradle.internal.http.socketTimeout=120000

--- a/tw-tasks-core-spring-boot-starter/src/main/java/com/transferwise/tasks/core/autoconfigure/TwTasksCoreAutoConfiguration.java
+++ b/tw-tasks-core-spring-boot-starter/src/main/java/com/transferwise/tasks/core/autoconfigure/TwTasksCoreAutoConfiguration.java
@@ -49,6 +49,7 @@ import com.transferwise.tasks.stucktasks.ITasksResumer;
 import com.transferwise.tasks.stucktasks.TasksResumer;
 import com.transferwise.tasks.triggering.ITasksExecutionTriggerer;
 import com.transferwise.tasks.triggering.KafkaTasksExecutionTriggerer;
+import java.util.List;
 import javax.sql.DataSource;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -255,6 +256,6 @@ public class TwTasksCoreAutoConfiguration {
 
   @Bean
   public NoOpTaskHandler noOpActionTaskHandler(TasksProperties tasksProperties) {
-    return new NoOpTaskHandler(tasksProperties.getNoOpTaskTypes());
+    return new NoOpTaskHandler(tasksProperties.getNoOpTaskTypes() == null ? List.of() : tasksProperties.getNoOpTaskTypes());
   }
 }

--- a/tw-tasks-core-spring-boot-starter/src/main/java/com/transferwise/tasks/core/autoconfigure/TwTasksCoreAutoConfiguration.java
+++ b/tw-tasks-core-spring-boot-starter/src/main/java/com/transferwise/tasks/core/autoconfigure/TwTasksCoreAutoConfiguration.java
@@ -27,6 +27,7 @@ import com.transferwise.tasks.entrypoints.EntryPointsService;
 import com.transferwise.tasks.entrypoints.IEntryPointsService;
 import com.transferwise.tasks.entrypoints.IMdcService;
 import com.transferwise.tasks.entrypoints.MdcService;
+import com.transferwise.tasks.handler.NoOpTaskHandler;
 import com.transferwise.tasks.handler.TaskHandlerRegistry;
 import com.transferwise.tasks.handler.interfaces.ITaskHandlerRegistry;
 import com.transferwise.tasks.health.ClusterWideTasksStateMonitor;
@@ -250,5 +251,10 @@ public class TwTasksCoreAutoConfiguration {
   @ConditionalOnMissingBean(IPartitionKeyStrategy.class)
   public IPartitionKeyStrategy twTasksPartitionKeyStrategy() {
     return new RandomPartitionKeyStrategy();
+  }
+
+  @Bean
+  public NoOpTaskHandler noOpActionTaskHandler(TasksProperties tasksProperties) {
+    return new NoOpTaskHandler(tasksProperties.getNoOpTaskTypes());
   }
 }

--- a/tw-tasks-core-spring-boot-starter/src/main/java/com/transferwise/tasks/core/autoconfigure/TwTasksCoreAutoConfiguration.java
+++ b/tw-tasks-core-spring-boot-starter/src/main/java/com/transferwise/tasks/core/autoconfigure/TwTasksCoreAutoConfiguration.java
@@ -255,7 +255,8 @@ public class TwTasksCoreAutoConfiguration {
   }
 
   @Bean
-  public NoOpTaskHandler noOpActionTaskHandler(TasksProperties tasksProperties) {
+  @ConditionalOnMissingBean(NoOpTaskHandler.class)
+  public NoOpTaskHandler twTasksNoOpTaskHandler(TasksProperties tasksProperties) {
     return new NoOpTaskHandler(tasksProperties.getNoOpTaskTypes() == null ? List.of() : tasksProperties.getNoOpTaskTypes());
   }
 }

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/TasksProperties.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/TasksProperties.java
@@ -354,6 +354,12 @@ public class TasksProperties {
   @jakarta.validation.Valid
   private ClusterWideTasksStateMonitor clusterWideTasksStateMonitor = new ClusterWideTasksStateMonitor();
 
+  /**
+   * Task types for which some tasks are still present in the database, and still yet to be executed. This will allow a NO-OP task
+   * handler to pick them up and execute them gracefully without creating noise for the service owners.
+   */
+  private List<String> noOpTaskTypes;
+
   public enum DbType {
     MYSQL, POSTGRES
   }

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/handler/NoOpTaskHandler.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/handler/NoOpTaskHandler.java
@@ -1,0 +1,68 @@
+package com.transferwise.tasks.handler;
+
+import com.transferwise.tasks.domain.IBaseTask;
+import com.transferwise.tasks.domain.ITask;
+import com.transferwise.tasks.handler.interfaces.ISyncTaskProcessor;
+import com.transferwise.tasks.handler.interfaces.ISyncTaskProcessor.ProcessResult.ResultCode;
+import com.transferwise.tasks.handler.interfaces.ITaskConcurrencyPolicy;
+import com.transferwise.tasks.handler.interfaces.ITaskHandler;
+import com.transferwise.tasks.handler.interfaces.ITaskProcessingPolicy;
+import com.transferwise.tasks.handler.interfaces.ITaskProcessor;
+import com.transferwise.tasks.handler.interfaces.ITaskRetryPolicy;
+import java.time.Duration;
+import java.util.List;
+import lombok.NonNull;
+
+public class NoOpTaskHandler implements ITaskHandler, ISyncTaskProcessor {
+  private static final int MAX_PROCESSING_ATTEMPTS = 10;
+
+  private ITaskRetryPolicy retryPolicy;
+  private ITaskProcessingPolicy processingPolicy;
+  private ITaskConcurrencyPolicy concurrencyPolicy;
+
+  private List<String> handledTaskTypes;
+
+  public NoOpTaskHandler(@NonNull List<String> handledTaskTypes) {
+    this.handledTaskTypes = handledTaskTypes;
+    this.retryPolicy = new ExponentialTaskRetryPolicy()
+        .setMaxCount(MAX_PROCESSING_ATTEMPTS)
+        .setDelay(Duration.ofSeconds(30));
+    this.concurrencyPolicy = new SimpleTaskConcurrencyPolicy(3);
+    this.processingPolicy =  new SimpleTaskProcessingPolicy().setMaxProcessingDuration(Duration.ofMinutes(2));
+  }
+
+  @Override
+  public boolean handles(IBaseTask task) {
+    return handledTaskTypes.contains(task.getType());
+  }
+
+  @Override
+  public ProcessResult process(ITask task) {
+    return new ProcessResult().setResultCode(ResultCode.DONE);
+  }
+
+  @Override
+  public ITaskProcessor getProcessor(IBaseTask task) {
+    return this;
+  }
+
+  @Override
+  public ITaskRetryPolicy getRetryPolicy(IBaseTask task) {
+    return retryPolicy;
+  }
+
+  @Override
+  public ITaskConcurrencyPolicy getConcurrencyPolicy(IBaseTask task) {
+    return concurrencyPolicy;
+  }
+
+  @Override
+  public ITaskProcessingPolicy getProcessingPolicy(IBaseTask task) {
+    return processingPolicy;
+  }
+
+  @Override
+  public boolean isTransactional(ITask task) {
+    return true;
+  }
+}

--- a/tw-tasks-core/src/test/java/com/transferwise/tasks/handler/NoOpTaskHandlerTest.java
+++ b/tw-tasks-core/src/test/java/com/transferwise/tasks/handler/NoOpTaskHandlerTest.java
@@ -1,0 +1,42 @@
+package com.transferwise.tasks.handler;
+
+
+import com.transferwise.tasks.domain.BaseTask;
+import com.transferwise.tasks.domain.IBaseTask;
+import com.transferwise.tasks.domain.ITask;
+import com.transferwise.tasks.domain.Task;
+import com.transferwise.tasks.handler.interfaces.ISyncTaskProcessor.ProcessResult.ResultCode;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class NoOpTaskHandlerTest {
+
+  @Test
+  void whenNoTaskTypeIsHandledByNoOpTaskHandler_thenCantHandle() {
+    NoOpTaskHandler noOpTaskHandler = new NoOpTaskHandler(List.of());
+    IBaseTask task = new BaseTask().setType("SOME_TASK_TYPE");
+    Assertions.assertThat(noOpTaskHandler.handles(task)).isFalse();
+  }
+
+  @Test
+  void whenTaskTypeIsNotHandledByNoOpTaskHandler_thenCantHandle() {
+    NoOpTaskHandler noOpTaskHandler = new NoOpTaskHandler(List.of("SOME_TASK_TYPE"));
+    IBaseTask task = new BaseTask().setType("SOME_OTHER_TASK_TYPE");
+    Assertions.assertThat(noOpTaskHandler.handles(task)).isFalse();
+  }
+
+  @Test
+  void whenTaskTypeIsHandledByNoOpTaskHandler_thenCanHandle() {
+    NoOpTaskHandler noOpTaskHandler = new NoOpTaskHandler(List.of("SOME_TASK_TYPE"));
+    IBaseTask task = new BaseTask().setType("SOME_TASK_TYPE");
+    Assertions.assertThat(noOpTaskHandler.handles(task)).isTrue();
+  }
+
+  @Test
+  void processReturnsASuccessfulResult() {
+    NoOpTaskHandler noOpTaskHandler = new NoOpTaskHandler(List.of("SOME_TASK_TYPE"));
+    ITask task = new Task().setType("SOME_TASK_TYPE");
+    Assertions.assertThat(noOpTaskHandler.process(task).getResultCode()).isEqualTo(ResultCode.DONE);
+  }
+}


### PR DESCRIPTION
## Context

We've had a case in one of our services where we had a task that could be scheduled up to 1 year in advance. We deprecated it many months ago. But because it was scheduled so far away in the future, we still regularly have these tasks failing in our services.

Since we have a lot of other tasks in the same service following the same schedule in advance pattern, we can't find these tasks in the ACTIVE tasks as they are drowned into other tasks scheduled.

We can't either filter by task type because there's no index for the task type in tw task library (rightfully), and thus the querying timeout before finding any meaningful number of tasks failed.

We thus get alerting about these failing tasks every day, and have to fix them manually

So I initially wanted to create a noop handler in our service and solve it once for all.


But I thought it would be nicer to provide a systematic solution for everyone instead.
So here we go!

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
