### PR TITLE
[APPENG-576] Add support for Spring Boot 3.1.2

### DIFF
--- a/.github/tw-rules.yaml
+++ b/.github/tw-rules.yaml
@@ -1,1 +1,9 @@
 runChecks: true
+
+actions:
+  branch-protection-settings:
+    branches:
+      - name: master
+        checks:
+          - name: Build and Test
+            type: tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,8 +23,8 @@ jobs:
       matrix:
         spring_boot_version:
           - 3.1.2
-          - 3.0.7
-          - 2.7.13
+          - 3.0.9
+          - 2.7.14
           - 2.6.15
     env:
       SPRING_BOOT_VERSION: ${{ matrix.spring_boot_version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,9 +22,10 @@ jobs:
       max-parallel: 100
       matrix:
         spring_boot_version:
-          - 3.0.6
-          - 2.7.11
-          - 2.6.14
+          - 3.1.2
+          - 3.0.7
+          - 2.7.13
+          - 2.6.15
     env:
       SPRING_BOOT_VERSION: ${{ matrix.spring_boot_version }}
       GRADLE_OPTS: "-Djava.security.egd=file:/dev/./urandom -Dorg.gradle.parallel=true"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### 1.40.3 - 2023/08/01
+
+### Added
+
+* Support for Spring Boot 3.1
+
+### Bumped
+
+* Build against Spring Boot 3.0.6 --> 3.0.7
+* Build against Spring Boot 2.7.11 --> 2.7.13
+* Build against Spring Boot 2.6.14 --> 2.6.15
+
 #### 1.40.2 - 2023/07/14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Bumped
 
-* Build against Spring Boot 3.0.6 --> 3.0.7
-* Build against Spring Boot 2.7.11 --> 2.7.13
+* Build against Spring Boot 3.0.6 --> 3.0.9
+* Build against Spring Boot 2.7.11 --> 2.7.14
 * Build against Spring Boot 2.6.14 --> 2.6.15
 
 #### 1.40.2 - 2023/07/14

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ import org.eclipse.jgit.api.errors.RefAlreadyExistsException
 
 buildscript {
     if (!project.hasProperty("springBootVersion")) {
-        ext.springBootVersion = System.getenv("SPRING_BOOT_VERSION") ?: "2.6.14"
+        ext.springBootVersion = System.getenv("SPRING_BOOT_VERSION") ?: "2.6.15"
     }
     dependencies {
         classpath "com.avast.gradle:gradle-docker-compose-plugin:0.16.4"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.40.2
+version=1.40.3
 org.gradle.internal.http.socketTimeout=120000

--- a/tw-tasks-kafka-listener/src/main/java/com/transferwise/tasks/helpers/kafka/messagetotask/CoreKafkaListener.java
+++ b/tw-tasks-kafka-listener/src/main/java/com/transferwise/tasks/helpers/kafka/messagetotask/CoreKafkaListener.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -27,6 +28,7 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
 
 @Slf4j
+@NoArgsConstructor
 public class CoreKafkaListener<T> implements GracefulShutdownStrategy, InitializingBean {
 
   @Autowired
@@ -51,6 +53,12 @@ public class CoreKafkaListener<T> implements GracefulShutdownStrategy, Initializ
   private volatile Map<Integer, List<MyTopic>> topicsShards;
   private List<String> kafkaDataCenterPrefixes;
   private final AtomicInteger inProgressPollers = new AtomicInteger();
+
+  // Required for @InjectMocks annotation used in tests to work in SB3.1
+  private CoreKafkaListener(IKafkaMessageHandlerRegistry<T> kafkaMessageHandlerRegistry, TasksProperties tasksProperties) {
+    this.kafkaMessageHandlerRegistry = kafkaMessageHandlerRegistry;
+    this.tasksProperties = tasksProperties;
+  }
 
   /**
    * Remember to set correct number of partitions for all topics here: @ https://octopus.tw.ee/kafka/topic/change . We could do it automatically, but


### PR DESCRIPTION
## Context

Spring Boot 3.1.2 is out now so adding support for that version in this library.

## Checklist
- [X] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
