### PR TITLE
Querying for Tasks by Type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,7 @@ target/
 build
 
 .idea
+*.iml
+*.ipr
+*.iws
 /demoapp/src/main/resources/application-rds.yml

--- a/tw-tasks-management/src/main/java/com/transferwise/tasks/management/ITasksManagementService.java
+++ b/tw-tasks-management/src/main/java/com/transferwise/tasks/management/ITasksManagementService.java
@@ -207,4 +207,31 @@ public interface ITasksManagementService {
       private Instant stateTime;
     }
   }
+
+  GetTasksByTypeResponse getTasksByType(GetTasksByTypeRequest request);
+
+  @Data
+  @Accessors(chain = true)
+  class GetTasksByTypeRequest {
+
+    private List<String> taskTypes = new ArrayList<>();
+  }
+
+  @Data
+  @Accessors(chain = true)
+  class GetTasksByTypeResponse {
+
+    private List<Task> tasks = new ArrayList<>();
+
+    @Data
+    @Accessors(chain = true)
+    public static class Task {
+
+      private TaskVersionId taskVersionId;
+      private String type;
+      private String subType;
+      private String status;
+      private Instant stateTime;
+    }
+  }
 }

--- a/tw-tasks-management/src/main/java/com/transferwise/tasks/management/TasksManagementService.java
+++ b/tw-tasks-management/src/main/java/com/transferwise/tasks/management/TasksManagementService.java
@@ -205,6 +205,25 @@ public class TasksManagementService implements ITasksManagementService {
 
   @Override
   @EntryPoint(usesExisting = true)
+  public GetTasksByTypeResponse getTasksByType(GetTasksByTypeRequest request) {
+    return entryPointsHelper
+        .continueOrCreate(ManagementEntryPointGroups.TW_TASKS_MANAGEMENT, ManagementEntryPointNames.GET_TASKS_BY_ID, () -> {
+          List<FullTaskRecord> tasks = managementTaskDao.getTasks(request.getTaskTypes());
+          return new GetTasksByIdResponse().setTasks(
+              tasks.stream().map(t -> new GetTasksByIdResponse.Task()
+                  .setTaskVersionId(new TaskVersionId().setId(t.getId()).setVersion(t.getVersion()))
+                  .setType(t.getType())
+                  .setSubType(t.getSubType())
+                  .setStatus(t.getStatus())
+                  .setStateTime(t.getStateTime().toInstant())
+              )
+                  .collect(Collectors.toList())
+          );
+        });
+  }
+
+  @Override
+  @EntryPoint(usesExisting = true)
   public GetTaskWithoutDataResponse getTaskWithoutData(UUID taskId) {
     return entryPointsHelper
         .continueOrCreate(ManagementEntryPointGroups.TW_TASKS_MANAGEMENT, ManagementEntryPointNames.GET_TASK_WITHOUT_DATA,

--- a/tw-tasks-management/src/main/java/com/transferwise/tasks/management/dao/IManagementTaskDao.java
+++ b/tw-tasks-management/src/main/java/com/transferwise/tasks/management/dao/IManagementTaskDao.java
@@ -52,4 +52,6 @@ public interface IManagementTaskDao {
   List<DaoTask3> getTasksInProcessingOrWaitingStatus(int maxCount);
 
   List<FullTaskRecord> getTasks(List<UUID> uuids);
+
+  List<FullTaskRecord> getTasksByType(List<String> types);
 }


### PR DESCRIPTION
## Context

In a particular use case, I'd want to be able to fetch all tasks by their declared Type. This PR would introduce that ability, as well as extracting out the similar use case of `getTasks(List<UUID> ids)` to share the same `FullTaskRecord` row mapping.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
