### PR TITLE
Fixing monitoring queries for Postgres finding approximate table sizes in the databases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### 1.40.4 - 2023/10/06
+
+### Fixed
+
+* Monitoring queries for Postgres finding approximate table sizes in the databases were using a wrong schema and thus no records were found.
+
 #### 1.40.3 - 2023/08/01
 
 ### Added

--- a/build.libraries.gradle
+++ b/build.libraries.gradle
@@ -22,6 +22,7 @@ ext {
             twLeaderSelectorStarter         : "com.transferwise.common:tw-leader-selector-starter:1.10.0",
             twBaseUtils                     : "com.transferwise.common:tw-base-utils:1.10.1",
             twEntryPointsStarter            : 'com.transferwise.common:tw-entrypoints-starter:2.10.0',
+            twSpyqlStarter                  : 'com.transferwise.common:tw-spyql-starter:1.6.1',
             lubenZstd                       : 'com.github.luben:zstd-jni:1.5.5-2',
             lz4Java                         : 'org.lz4:lz4-java:1.8.0',
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.40.3
+version=1.40.4
 org.gradle.internal.http.socketTimeout=120000

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     testImplementation libraries.mariadbJavaClient
     testImplementation libraries.springKafka
     testImplementation libraries.awaitility
+    testImplementation libraries.twSpyqlStarter
 
     testRuntimeOnly project(":tw-tasks-core-test-spring-boot-starter")
     testRuntimeOnly project(":tw-tasks-jobs-test-spring-boot-starter")

--- a/integration-tests/src/test/java/com/transferwise/tasks/testapp/dao/PostgresTaskDaoIntTest.java
+++ b/integration-tests/src/test/java/com/transferwise/tasks/testapp/dao/PostgresTaskDaoIntTest.java
@@ -13,6 +13,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 @ActiveProfiles("postgres")
 class PostgresTaskDaoIntTest extends TaskDaoIntTest {
+
   @Test
   @SneakyThrows
   void approximateTaskCountCanBeRetrieved() {
@@ -22,7 +23,9 @@ class PostgresTaskDaoIntTest extends TaskDaoIntTest {
       @Override
       public void onStatementExecute(StatementExecuteEvent event) {
         // Check if correct schema is set.
-        if (event.getSql().equals("SELECT reltuples as approximate_row_count FROM pg_class, pg_namespace WHERE  pg_class.relnamespace=pg_namespace.oid and nspname='public' and relname = 'tw_task'")){
+        if (event.getSql().equals(
+            "SELECT reltuples as approximate_row_count FROM pg_class, pg_namespace WHERE "
+                + " pg_class.relnamespace=pg_namespace.oid and nspname='public' and relname = 'tw_task'")) {
           correctSqlEncountered.set(true);
         }
       }
@@ -33,8 +36,7 @@ class PostgresTaskDaoIntTest extends TaskDaoIntTest {
     try {
       assertThat(taskDao.getApproximateTasksCount()).isGreaterThan(-1);
       assertThat(correctSqlEncountered).isTrue();
-    }
-    finally {
+    } finally {
       spyqlDataSource.getDataSourceListeners().remove(spyqlDataSourceListener);
     }
   }

--- a/integration-tests/src/test/java/com/transferwise/tasks/testapp/dao/PostgresTaskDaoIntTest.java
+++ b/integration-tests/src/test/java/com/transferwise/tasks/testapp/dao/PostgresTaskDaoIntTest.java
@@ -1,8 +1,41 @@
 package com.transferwise.tasks.testapp.dao;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.transferwise.common.spyql.SpyqlDataSource;
+import com.transferwise.common.spyql.event.StatementExecuteEvent;
+import com.transferwise.common.spyql.listener.SpyqlConnectionListener;
+import com.transferwise.common.spyql.listener.SpyqlDataSourceListener;
+import java.util.concurrent.atomic.AtomicBoolean;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ActiveProfiles;
 
 @ActiveProfiles("postgres")
 class PostgresTaskDaoIntTest extends TaskDaoIntTest {
+  @Test
+  @SneakyThrows
+  void approximateTaskCountCanBeRetrieved() {
+    var correctSqlEncountered = new AtomicBoolean();
+    var spyqlDataSource = dataSource.unwrap(SpyqlDataSource.class);
+    final SpyqlDataSourceListener spyqlDataSourceListener = event -> new SpyqlConnectionListener() {
+      @Override
+      public void onStatementExecute(StatementExecuteEvent event) {
+        // Check if correct schema is set.
+        if (event.getSql().equals("SELECT reltuples as approximate_row_count FROM pg_class, pg_namespace WHERE  pg_class.relnamespace=pg_namespace.oid and nspname='public' and relname = 'tw_task'")){
+          correctSqlEncountered.set(true);
+        }
+      }
+    };
 
+    spyqlDataSource.addListener(spyqlDataSourceListener);
+
+    try {
+      assertThat(taskDao.getApproximateTasksCount()).isGreaterThan(-1);
+      assertThat(correctSqlEncountered).isTrue();
+    }
+    finally {
+      spyqlDataSource.getDataSourceListeners().remove(spyqlDataSourceListener);
+    }
+  }
 }

--- a/integration-tests/src/test/java/com/transferwise/tasks/testapp/dao/TaskDaoIntTest.java
+++ b/integration-tests/src/test/java/com/transferwise/tasks/testapp/dao/TaskDaoIntTest.java
@@ -538,7 +538,7 @@ abstract class TaskDaoIntTest extends BaseIntTest {
       @Override
       public void onStatementExecute(StatementExecuteEvent event) {
         // Correct schema is used.
-        if (event.getSql().equals("select table_rows from information_schema.tables where table_schema='tw-tasks-test' and table_name = 'tw_task'")){
+        if (event.getSql().equals("select table_rows from information_schema.tables where table_schema='tw-tasks-test' and table_name = 'tw_task'")) {
           correctSqlEncountered.set(true);
         }
       }
@@ -549,8 +549,7 @@ abstract class TaskDaoIntTest extends BaseIntTest {
     try {
       assertThat(taskDao.getApproximateTasksCount()).isGreaterThan(-1);
       assertThat(correctSqlEncountered).isTrue();
-    }
-    finally {
+    } finally {
       spyqlDataSource.getDataSourceListeners().remove(spyqlDataSourceListener);
     }
   }

--- a/integration-tests/src/test/resources/config/application.yml
+++ b/integration-tests/src/test/resources/config/application.yml
@@ -76,6 +76,8 @@ spring:
     url: jdbc:mariadb://${MARIADB_HOST:localhost}:${MARIADB_TCP_3306}/tw-tasks-test?rewriteBatchStatements=false
     username: root
     password: example-password-change-me
+    hikari:
+      pool-name: tw-tasks-test
   kafka:
     client-id: test-mysql
     consumer:

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/dao/PostgresTaskDao.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/dao/PostgresTaskDao.java
@@ -41,7 +41,7 @@ public class PostgresTaskDao extends JdbcTaskDao implements InitializingBean {
   @Override
   protected String getApproximateTableCountSql(boolean withSchema, String table) {
     String schema = "current_schema()";
-    if (!withSchema) {
+    if (withSchema) {
       schema = "'" + tasksProperties.getTaskTablesSchemaName() + "'";
     }
 


### PR DESCRIPTION
## Context

### Fixed

* Monitoring queries for Postgres finding approximate table sizes in the databases were using a wrong schema and thus no records were found.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
