### PR TITLE
[RDP-1913]Reduce metadata refresh interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### 1.40.5 - 2023/10/30
+### Added
+- Setting METADATA_MAX_AGE_CONFIG to two minutes for producer
+
 #### 1.40.4 - 2023/10/06
 
 ### Fixed

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.40.4
+version=1.40.5
 org.gradle.internal.http.socketTimeout=120000

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/triggering/KafkaTasksExecutionTriggerer.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/triggering/KafkaTasksExecutionTriggerer.java
@@ -490,6 +490,7 @@ public class KafkaTasksExecutionTriggerer implements ITasksExecutionTriggerer, G
     configs.put(ProducerConfig.CLIENT_ID_CONFIG, tasksProperties.getGroupId() + ".tw-tasks-triggerer");
     configs.put(ProducerConfig.RECONNECT_BACKOFF_MAX_MS_CONFIG, "5000");
     configs.put(ProducerConfig.RECONNECT_BACKOFF_MS_CONFIG, "100");
+    configs.put(ProducerConfig.METADATA_MAX_AGE_CONFIG, "120000");
 
     configs.putAll(tasksProperties.getTriggering().getKafka().getProperties());
 


### PR DESCRIPTION
## Context

The goal with this change is to provide more time for https://github.com/transferwise/kafka-health-checker to demote unhealthy brokers. We assume that faulty broker is in a zombie state, so it won't return `PARTITION_MIGRATED` exception that would force the metadata update. Default `metadata.max.age.ms` is 5 min. Producer’s delivery timeout is 7 min. Let’s say trouble starts at 13:01, health checker reacts to this and demotes the broker at 13:04, if Kafka client’s metadata was refreshed at 13:03, then next metadata refresh will be at 13:08, by that time we would already hit delivery timeout, which would be at 13:08. If producers producing to a changelog topic fail, then it forces the whole Kafka streams task to migrate to another instance, hence the rebalancing. Problem will be that exception will be thrown when produce fails within the delivery timeout, leading the Kafka Streams thread to be moved to another instance. Producer metadata is refreshed periodically, or if there’re certain exceptions returned by the broker. 

Source: https://wise.slack.com/archives/G01P8RBLGCC/p1693400446185769

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 


## Details from ticket: [RDP-1913](https://transferwise.atlassian.net/browse/RDP-1913)

### Reduce metadata refresh interval for Service Kafka clients

>When we implement the {{kafka-health-checker}} features for the Service Kafka cluster, we should also make sure that clients set {{metadata.max.age.ms=120000}} (two minutes) to reduce impact time.


[RDP-1913]: https://transferwise.atlassian.net/browse/RDP-1913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ