### PR TITLE
add endpoint to get task types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### 1.41.0 - 2023/11/16
+### Added
+- Added `taskType` and `taskSubType` parameters to management query endpoints.
+- Added `/getTaskTypes` endpoint to retrieve list of registered task types and sub-types
+
 ## 1.40.6 - 2023/11/16
 ### Fixed
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.40.6
+version=1.41.0
 org.gradle.internal.http.socketTimeout=120000

--- a/integration-tests/src/test/java/com/transferwise/tasks/ext/management/dao/ManagementTaskDaoIntTest.java
+++ b/integration-tests/src/test/java/com/transferwise/tasks/ext/management/dao/ManagementTaskDaoIntTest.java
@@ -77,7 +77,7 @@ abstract class ManagementTaskDaoIntTest extends BaseIntTest {
     randomProcessingTask().withSubType("3").save();
     randomErrorTask().withSubType("4").save();
 
-    List<DaoTask1> tasks = managementTaskDao.getTasksInErrorStatus(2);
+    List<DaoTask1> tasks = managementTaskDao.getTasksInErrorStatus(2, null, null);
 
     assertEquals(2, tasks.size());
     for (DaoTask1 task : tasks) {
@@ -93,7 +93,7 @@ abstract class ManagementTaskDaoIntTest extends BaseIntTest {
     randomProcessingTask().withSubType("4").save();
     randomWaitingTask().withSubType("5").save();
 
-    List<DaoTask3> tasks = managementTaskDao.getTasksInProcessingOrWaitingStatus(3);
+    List<DaoTask3> tasks = managementTaskDao.getTasksInProcessingOrWaitingStatus(3, null, null);
 
     assertEquals(3, tasks.size());
     assertEquals(3, tasks.stream().filter(t -> ImmutableSet.of("1", "3", "4", "5").contains(t.getSubType())).count());
@@ -114,7 +114,7 @@ abstract class ManagementTaskDaoIntTest extends BaseIntTest {
     randomDoneTask().save();
     randomWaitingTask().save();
 
-    List<DaoTask2> tasks = managementTaskDao.getStuckTasks(4, Duration.ofMillis(-2));
+    List<DaoTask2> tasks = managementTaskDao.getStuckTasks(4, null, null, Duration.ofMillis(-2));
 
     assertEquals(4, tasks.size());
   }

--- a/integration-tests/src/test/java/com/transferwise/tasks/testapp/TaskProcessingIntTest.java
+++ b/integration-tests/src/test/java/com/transferwise/tasks/testapp/TaskProcessingIntTest.java
@@ -214,7 +214,7 @@ public class TaskProcessingIntTest extends BaseIntTest {
       }
 
       List<DaoTask1> error = transactionsHelper.withTransaction().asNew().call(() ->
-          managementTaskDao.getTasksInErrorStatus(10)
+          managementTaskDao.getTasksInErrorStatus(10, null, null)
       );
       boolean taskWasMarkedAsError = error.size() != 0 && error.get(0).getId().equals(taskRef.get().getTaskId());
       if (taskWasMarkedAsError) {

--- a/integration-tests/src/test/java/com/transferwise/tasks/testapp/TasksManagementPortIntTest.java
+++ b/integration-tests/src/test/java/com/transferwise/tasks/testapp/TasksManagementPortIntTest.java
@@ -17,9 +17,12 @@ import com.transferwise.tasks.domain.TaskVersionId;
 import com.transferwise.tasks.management.ITasksManagementPort;
 import com.transferwise.tasks.management.ITasksManagementPort.GetTaskDataResponse;
 import com.transferwise.tasks.management.ITasksManagementPort.GetTaskDataResponse.ResultCode;
+import com.transferwise.tasks.management.ITasksManagementPort.GetTaskTypesResponse;
 import com.transferwise.tasks.management.ITasksManagementPort.GetTaskWithoutDataResponse;
 import com.transferwise.tasks.management.ITasksManagementPort.GetTasksInErrorResponse;
 import com.transferwise.tasks.management.ITasksManagementPort.GetTasksInErrorResponse.TaskInError;
+import com.transferwise.tasks.management.ITasksManagementPort.GetTasksInProcessingOrWaitingResponse;
+import com.transferwise.tasks.management.ITasksManagementPort.GetTasksInProcessingOrWaitingResponse.TaskInProcessingOrWaiting;
 import com.transferwise.tasks.management.ITasksManagementPort.GetTasksStuckResponse;
 import com.transferwise.tasks.management.ITasksManagementPort.GetTasksStuckResponse.TaskStuck;
 import java.time.ZonedDateTime;
@@ -352,6 +355,161 @@ public class TasksManagementPortIntTest extends BaseIntTest {
     FullTaskRecord task = taskDao.getTask(task0Id, FullTaskRecord.class);
     // decrementing 1 because of database rounding error
     assertFalse(task.getNextEventTime().isAfter(ZonedDateTime.now(TwContextClockHolder.getClock()).plusSeconds(1)));
+  }
+
+  @Test
+  void filtersErroredTasksByTypeAndSubType() {
+    final UUID taskId = transactionsHelper.withTransaction().asNew().call(() -> {
+      TaskTestBuilder.newTask().inStatus(TaskStatus.ERROR).withMaxStuckTime(ZonedDateTime.now().plusDays(2)).save();
+      TaskTestBuilder.newTask().inStatus(TaskStatus.ERROR).withMaxStuckTime(ZonedDateTime.now().plusDays(2))
+          .withType("B")
+          .withSubType("SUB")
+          .save();
+      TaskTestBuilder.newTask().inStatus(TaskStatus.ERROR).withMaxStuckTime(ZonedDateTime.now().plusDays(2))
+          .withType("A")
+          .withSubType("BAD")
+          .save();
+      TaskTestBuilder.newTask().inStatus(TaskStatus.ERROR).withMaxStuckTime(ZonedDateTime.now().plusDays(2))
+          .withSubType("SUB")
+          .save();
+      return TaskTestBuilder.newTask().inStatus(TaskStatus.ERROR).withMaxStuckTime(ZonedDateTime.now().plusDays(2))
+          .withType("A")
+          .withSubType("SUB")
+          .save()
+          .getTaskId();
+    });
+
+    ResponseEntity<GetTasksInErrorResponse> response = goodEngineerTemplate().postForEntity(
+        "/v1/twTasks/getTasksInError",
+        new ITasksManagementPort.GetTasksInErrorRequest().setMaxCount(10).setTaskType("A").setTaskSubType("SUB"),
+        GetTasksInErrorResponse.class
+    );
+
+    assertEquals(200, response.getStatusCodeValue());
+    GetTasksInErrorResponse tasksInErrorResponse = response.getBody();
+    assertNotNull(tasksInErrorResponse);
+    List<TaskInError> tasksInError = tasksInErrorResponse.getTasksInError();
+    assertEquals(1, tasksInError.size());
+    assertEquals(taskId, tasksInError.get(0).getTaskVersionId().getId());
+    assertEquals("A", tasksInError.get(0).getType());
+    assertEquals("SUB", tasksInError.get(0).getSubType());
+  }
+
+  @Test
+  void filtersStuckTasksByTypeAndSubType() {
+    testTasksService.stopProcessing();
+
+    final UUID taskId = transactionsHelper.withTransaction().asNew().call(() -> {
+      TaskTestBuilder.newTask().inStatus(TaskStatus.PROCESSING).withMaxStuckTime(ZonedDateTime.now().minusDays(2)).save();
+      TaskTestBuilder.newTask().inStatus(TaskStatus.PROCESSING).withMaxStuckTime(ZonedDateTime.now().minusDays(2))
+          .withType("B")
+          .withSubType("SUB")
+          .save();
+      TaskTestBuilder.newTask().inStatus(TaskStatus.PROCESSING).withMaxStuckTime(ZonedDateTime.now().minusDays(2))
+          .withType("A")
+          .withSubType("BAD")
+          .save();
+      TaskTestBuilder.newTask().inStatus(TaskStatus.PROCESSING).withMaxStuckTime(ZonedDateTime.now().minusDays(2))
+          .withSubType("SUB")
+          .save();
+      return TaskTestBuilder.newTask().inStatus(TaskStatus.PROCESSING).withMaxStuckTime(ZonedDateTime.now().minusDays(2))
+          .withType("A")
+          .withSubType("SUB")
+          .save()
+          .getTaskId();
+    });
+
+    ResponseEntity<ITasksManagementPort.GetTasksStuckResponse> response = goodEngineerTemplate().postForEntity(
+        "/v1/twTasks/getTasksStuck",
+        new ITasksManagementPort.GetTasksStuckRequest().setMaxCount(10).setTaskType("A").setTaskSubType("SUB"),
+        ITasksManagementPort.GetTasksStuckResponse.class
+    );
+
+    assertEquals(200, response.getStatusCodeValue());
+    GetTasksStuckResponse stuckTasksResponse = response.getBody();
+    assertNotNull(stuckTasksResponse);
+    List<TaskStuck> tasksStuck = stuckTasksResponse.getTasksStuck();
+    assertEquals(1, tasksStuck.size());
+    assertEquals(taskId, tasksStuck.get(0).getTaskVersionId().getId());
+  }
+
+  @Test
+  void filtersWaitingTasksByTypeAndSubType() {
+    final UUID taskId = transactionsHelper.withTransaction().asNew().call(() -> {
+      TaskTestBuilder.newTask().inStatus(TaskStatus.WAITING).withMaxStuckTime(ZonedDateTime.now().plusDays(2)).save();
+      TaskTestBuilder.newTask().inStatus(TaskStatus.WAITING).withMaxStuckTime(ZonedDateTime.now().plusDays(2))
+          .withType("B")
+          .withSubType("SUB")
+          .save();
+      TaskTestBuilder.newTask().inStatus(TaskStatus.WAITING).withMaxStuckTime(ZonedDateTime.now().plusDays(2))
+          .withType("A")
+          .withSubType("BAD")
+          .save();
+      TaskTestBuilder.newTask().inStatus(TaskStatus.WAITING).withMaxStuckTime(ZonedDateTime.now().plusDays(2))
+          .withSubType("SUB")
+          .save();
+      return TaskTestBuilder.newTask().inStatus(TaskStatus.WAITING).withMaxStuckTime(ZonedDateTime.now().plusDays(2))
+          .withType("A")
+          .withSubType("SUB")
+          .save()
+          .getTaskId();
+    });
+
+    ResponseEntity<GetTasksInProcessingOrWaitingResponse> response = goodEngineerTemplate().postForEntity(
+        "/v1/twTasks/getTasksInProcessingOrWaiting",
+        new ITasksManagementPort.GetTasksInProcessingOrWaitingRequest().setMaxCount(10).setTaskType("A").setTaskSubType("SUB"),
+        GetTasksInProcessingOrWaitingResponse.class
+    );
+
+    assertEquals(
+        200, response.getStatusCodeValue());
+    GetTasksInProcessingOrWaitingResponse waitingTasksResponse = response.getBody();
+    assertNotNull(waitingTasksResponse);
+    List<TaskInProcessingOrWaiting> tasksWaiting = waitingTasksResponse.getTasksInProcessingOrWaiting();
+    assertEquals(1, tasksWaiting.size());
+    assertEquals(taskId, tasksWaiting.get(0).getTaskVersionId().getId());
+    assertEquals("A", tasksWaiting.get(0).getType());
+    assertEquals("SUB", tasksWaiting.get(0).getSubType());
+  }
+
+  @Test
+  void getTaskTypesWillReturnCorrectly() {
+    transactionsHelper.withTransaction().asNew().run(() -> {
+      TaskTestBuilder.newTask().inStatus(TaskStatus.WAITING).withMaxStuckTime(ZonedDateTime.now().plusDays(2))
+          .withType("A")
+          .withSubType("SUB-2")
+          .save();
+      TaskTestBuilder.newTask().inStatus(TaskStatus.WAITING).withMaxStuckTime(ZonedDateTime.now().plusDays(2))
+          .withType("A")
+          .withSubType("SUB-1")
+          .save();
+      TaskTestBuilder.newTask().inStatus(TaskStatus.WAITING).withMaxStuckTime(ZonedDateTime.now().plusDays(2))
+          .withType("B")
+          .save();
+      TaskTestBuilder.newTask().inStatus(TaskStatus.WAITING).withMaxStuckTime(ZonedDateTime.now().plusDays(2))
+          .withType("A")
+          .save();
+      TaskTestBuilder.newTask().inStatus(TaskStatus.WAITING).withMaxStuckTime(ZonedDateTime.now().plusDays(2))
+          .withType("B")
+          .save();
+    });
+
+    ResponseEntity<GetTaskTypesResponse> response = goodEngineerTemplate().getForEntity(
+        "/v1/twTasks/getTaskTypes",
+        GetTaskTypesResponse.class
+    );
+
+    assertEquals(200, response.getStatusCodeValue());
+    GetTaskTypesResponse typesResponse = response.getBody();
+    assertNotNull(typesResponse);
+    List<GetTaskTypesResponse.TaskType> types = typesResponse.getTypes();
+    assertEquals(2, types.size());
+    assertEquals("A", types.get(0).getType());
+    assertEquals("B", types.get(1).getType());
+    assertEquals(2, types.get(0).getSubTypes().size());
+    assertEquals("SUB-1", types.get(0).getSubTypes().get(0));
+    assertEquals("SUB-2", types.get(0).getSubTypes().get(1));
+    assertTrue(types.get(1).getSubTypes().isEmpty());
   }
 
   private TestRestTemplate goodEngineerTemplate() {

--- a/integration-tests/src/test/java/com/transferwise/tasks/testapp/TasksManagementPortIntTest.java
+++ b/integration-tests/src/test/java/com/transferwise/tasks/testapp/TasksManagementPortIntTest.java
@@ -381,7 +381,9 @@ public class TasksManagementPortIntTest extends BaseIntTest {
 
     ResponseEntity<GetTasksInErrorResponse> response = goodEngineerTemplate().postForEntity(
         "/v1/twTasks/getTasksInError",
-        new ITasksManagementPort.GetTasksInErrorRequest().setMaxCount(10).setTaskType("A").setTaskSubType("SUB"),
+        new ITasksManagementPort.GetTasksInErrorRequest().setMaxCount(10)
+            .setTaskTypes(List.of("A"))
+            .setTaskSubTypes(List.of("SUB")),
         GetTasksInErrorResponse.class
     );
 
@@ -421,7 +423,9 @@ public class TasksManagementPortIntTest extends BaseIntTest {
 
     ResponseEntity<ITasksManagementPort.GetTasksStuckResponse> response = goodEngineerTemplate().postForEntity(
         "/v1/twTasks/getTasksStuck",
-        new ITasksManagementPort.GetTasksStuckRequest().setMaxCount(10).setTaskType("A").setTaskSubType("SUB"),
+        new ITasksManagementPort.GetTasksStuckRequest().setMaxCount(10)
+            .setTaskTypes(List.of("A"))
+            .setTaskSubTypes(List.of("SUB")),
         ITasksManagementPort.GetTasksStuckResponse.class
     );
 
@@ -457,7 +461,9 @@ public class TasksManagementPortIntTest extends BaseIntTest {
 
     ResponseEntity<GetTasksInProcessingOrWaitingResponse> response = goodEngineerTemplate().postForEntity(
         "/v1/twTasks/getTasksInProcessingOrWaiting",
-        new ITasksManagementPort.GetTasksInProcessingOrWaitingRequest().setMaxCount(10).setTaskType("A").setTaskSubType("SUB"),
+        new ITasksManagementPort.GetTasksInProcessingOrWaitingRequest().setMaxCount(10)
+            .setTaskTypes(List.of("A"))
+            .setTaskSubTypes(List.of("SUB")),
         GetTasksInProcessingOrWaitingResponse.class
     );
 

--- a/tw-tasks-management/src/main/java/com/transferwise/tasks/management/ITasksManagementPort.java
+++ b/tw-tasks-management/src/main/java/com/transferwise/tasks/management/ITasksManagementPort.java
@@ -140,6 +140,11 @@ public interface ITasksManagementPort {
   @ResponseBody
   ResponseEntity<GetTasksByIdResponse> getTasksById(@RequestBody GetTasksByIdRequest request);
 
+  @GetMapping(value = "${tw-tasks.core.base-url:}/v1/twTasks/getTaskTypes", produces = {MediaType.APPLICATION_JSON_VALUE})
+  @ResponseBody
+  ResponseEntity<GetTaskTypesResponse> getTaskTypes();
+
+
   @Data
   @Accessors(chain = true)
   class GetTasksByIdRequest {
@@ -186,8 +191,9 @@ public interface ITasksManagementPort {
   @Data
   @Accessors(chain = true)
   class GetTasksInErrorRequest {
-
     private int maxCount;
+    String taskType;
+    String taskSubType;
   }
 
   @Data
@@ -195,6 +201,8 @@ public interface ITasksManagementPort {
   class GetTasksInProcessingOrWaitingRequest {
 
     private int maxCount;
+    String taskType;
+    String taskSubType;
   }
 
   @Data
@@ -241,6 +249,8 @@ public interface ITasksManagementPort {
   class GetTasksStuckRequest {
 
     private int maxCount;
+    String taskType;
+    String taskSubType;
   }
 
   @Data
@@ -255,6 +265,19 @@ public interface ITasksManagementPort {
 
       private TaskVersionId taskVersionId;
       private Instant stuckTime;
+    }
+  }
+
+  @Data
+  @Accessors(chain = true)
+  class GetTaskTypesResponse {
+    private List<TaskType> types;
+
+    @Data
+    @Accessors(chain = true)
+    public static class TaskType {
+      private String type;
+      private List<String> subTypes;
     }
   }
 }

--- a/tw-tasks-management/src/main/java/com/transferwise/tasks/management/ITasksManagementPort.java
+++ b/tw-tasks-management/src/main/java/com/transferwise/tasks/management/ITasksManagementPort.java
@@ -192,8 +192,8 @@ public interface ITasksManagementPort {
   @Accessors(chain = true)
   class GetTasksInErrorRequest {
     private int maxCount;
-    String taskType;
-    String taskSubType;
+    List<String> taskTypes;
+    List<String> taskSubTypes;
   }
 
   @Data
@@ -201,8 +201,8 @@ public interface ITasksManagementPort {
   class GetTasksInProcessingOrWaitingRequest {
 
     private int maxCount;
-    String taskType;
-    String taskSubType;
+    List<String> taskTypes;
+    List<String> taskSubTypes;
   }
 
   @Data
@@ -249,8 +249,8 @@ public interface ITasksManagementPort {
   class GetTasksStuckRequest {
 
     private int maxCount;
-    String taskType;
-    String taskSubType;
+    List<String> taskTypes;
+    List<String> taskSubTypes;
   }
 
   @Data

--- a/tw-tasks-management/src/main/java/com/transferwise/tasks/management/ITasksManagementService.java
+++ b/tw-tasks-management/src/main/java/com/transferwise/tasks/management/ITasksManagementService.java
@@ -110,8 +110,8 @@ public interface ITasksManagementService {
   class GetTasksInErrorRequest {
 
     private int maxCount;
-    private String taskType;
-    private String taskSubType;
+    private List<String> taskTypes;
+    private List<String> taskSubTypes;
   }
 
   @Data
@@ -139,8 +139,8 @@ public interface ITasksManagementService {
 
     private int maxCount;
     private Duration delta;
-    private String taskType;
-    private String taskSubType;
+    private List<String> taskTypes;
+    private List<String> taskSubTypes;
   }
 
   @Data
@@ -165,8 +165,8 @@ public interface ITasksManagementService {
   class GetTasksInProcessingOrWaitingRequest {
 
     private int maxCount = 10;
-    private String taskType;
-    private String taskSubType;
+    private List<String> taskTypes;
+    private List<String> taskSubTypes;
   }
 
   @Data

--- a/tw-tasks-management/src/main/java/com/transferwise/tasks/management/ITasksManagementService.java
+++ b/tw-tasks-management/src/main/java/com/transferwise/tasks/management/ITasksManagementService.java
@@ -110,6 +110,8 @@ public interface ITasksManagementService {
   class GetTasksInErrorRequest {
 
     private int maxCount;
+    private String taskType;
+    private String taskSubType;
   }
 
   @Data
@@ -137,6 +139,8 @@ public interface ITasksManagementService {
 
     private int maxCount;
     private Duration delta;
+    private String taskType;
+    private String taskSubType;
   }
 
   @Data
@@ -161,6 +165,8 @@ public interface ITasksManagementService {
   class GetTasksInProcessingOrWaitingRequest {
 
     private int maxCount = 10;
+    private String taskType;
+    private String taskSubType;
   }
 
   @Data
@@ -205,6 +211,21 @@ public interface ITasksManagementService {
       private String subType;
       private String status;
       private Instant stateTime;
+    }
+  }
+
+  GetTaskTypesResponse getTaskTypes();
+
+  @Data
+  @Accessors(chain = true)
+  class GetTaskTypesResponse {
+    private List<TaskType> types;
+
+    @Data
+    @Accessors(chain = true)
+    public static class TaskType {
+      private String type;
+      private List<String> subTypes;
     }
   }
 }

--- a/tw-tasks-management/src/main/java/com/transferwise/tasks/management/ManagementEntryPointNames.java
+++ b/tw-tasks-management/src/main/java/com/transferwise/tasks/management/ManagementEntryPointNames.java
@@ -11,6 +11,7 @@ public final class ManagementEntryPointNames {
   public static final String MARK_AS_FAILED = "markAsFailed";
   public static final String GET_TASK_WITHOUT_DATA = "getTaskWithoutData";
   public static final String GET_TASK_DATA = "getTaskData";
+  public static final String GET_TASKS_TYPES = "getTasksTypes";
 
   private ManagementEntryPointNames() {
     throw new AssertionError();

--- a/tw-tasks-management/src/main/java/com/transferwise/tasks/management/TasksManagementPortController.java
+++ b/tw-tasks-management/src/main/java/com/transferwise/tasks/management/TasksManagementPortController.java
@@ -99,6 +99,8 @@ public class TasksManagementPortController implements ITasksManagementPort, Init
     return callWithAuthentication(() -> {
       ITasksManagementService.GetTasksInErrorResponse serviceResponse = tasksManagementService
           .getTasksInError(new ITasksManagementService.GetTasksInErrorRequest()
+              .setTaskType(request != null ? request.getTaskType() : null)
+              .setTaskSubType(request != null ? request.getTaskSubType() : null)
               .setMaxCount(request != null ? request.getMaxCount() : DEFAULT_MAX_COUNT));
 
       return ResponseEntity.ok(new GetTasksInErrorResponse().setTasksInError(serviceResponse.getTasksInError().stream().map(taskInError ->
@@ -140,6 +142,8 @@ public class TasksManagementPortController implements ITasksManagementPort, Init
     return callWithAuthentication(() -> {
       ITasksManagementService.GetTasksInProcessingOrWaitingResponse serviceResponse = tasksManagementService
           .getTasksInProcessingOrWaiting(new ITasksManagementService.GetTasksInProcessingOrWaitingRequest()
+              .setTaskType(request != null ? request.getTaskType() : null)
+              .setTaskSubType(request != null ? request.getTaskSubType() : null)
               .setMaxCount(request != null ? request.getMaxCount() : DEFAULT_MAX_COUNT));
 
       return ResponseEntity.ok(new GetTasksInProcessingOrWaitingResponse()
@@ -184,11 +188,23 @@ public class TasksManagementPortController implements ITasksManagementPort, Init
     return callWithAuthentication(() -> {
       ITasksManagementService.GetTasksStuckResponse serviceResponse = tasksManagementService
           .getTasksStuck(new ITasksManagementService.GetTasksStuckRequest()
+              .setTaskType(request != null ? request.getTaskType() : null)
+              .setTaskSubType(request != null ? request.getTaskSubType() : null)
               .setMaxCount(request != null ? request.getMaxCount() : DEFAULT_MAX_COUNT));
 
       return ResponseEntity.ok(new GetTasksStuckResponse().setTasksStuck(serviceResponse.getTasksStuck().stream().map(taskStuck ->
           new GetTasksStuckResponse.TaskStuck().setStuckTime(taskStuck.getStuckTime())
               .setTaskVersionId(taskStuck.getTaskVersionId())).collect(Collectors.toList())));
+    });
+  }
+
+  @Override
+  public ResponseEntity<GetTaskTypesResponse> getTaskTypes() {
+    return callWithAuthentication(() -> {
+      ITasksManagementService.GetTaskTypesResponse serviceResponse = tasksManagementService.getTaskTypes();
+
+      return ResponseEntity.ok(new GetTaskTypesResponse().setTypes(serviceResponse.getTypes().stream().map(type ->
+          new GetTaskTypesResponse.TaskType().setType(type.getType()).setSubTypes(type.getSubTypes())).collect(Collectors.toList())));
     });
   }
 

--- a/tw-tasks-management/src/main/java/com/transferwise/tasks/management/TasksManagementPortController.java
+++ b/tw-tasks-management/src/main/java/com/transferwise/tasks/management/TasksManagementPortController.java
@@ -99,8 +99,8 @@ public class TasksManagementPortController implements ITasksManagementPort, Init
     return callWithAuthentication(() -> {
       ITasksManagementService.GetTasksInErrorResponse serviceResponse = tasksManagementService
           .getTasksInError(new ITasksManagementService.GetTasksInErrorRequest()
-              .setTaskType(request != null ? request.getTaskType() : null)
-              .setTaskSubType(request != null ? request.getTaskSubType() : null)
+              .setTaskTypes(request != null ? request.getTaskTypes() : null)
+              .setTaskSubTypes(request != null ? request.getTaskSubTypes() : null)
               .setMaxCount(request != null ? request.getMaxCount() : DEFAULT_MAX_COUNT));
 
       return ResponseEntity.ok(new GetTasksInErrorResponse().setTasksInError(serviceResponse.getTasksInError().stream().map(taskInError ->
@@ -142,8 +142,8 @@ public class TasksManagementPortController implements ITasksManagementPort, Init
     return callWithAuthentication(() -> {
       ITasksManagementService.GetTasksInProcessingOrWaitingResponse serviceResponse = tasksManagementService
           .getTasksInProcessingOrWaiting(new ITasksManagementService.GetTasksInProcessingOrWaitingRequest()
-              .setTaskType(request != null ? request.getTaskType() : null)
-              .setTaskSubType(request != null ? request.getTaskSubType() : null)
+              .setTaskTypes(request != null ? request.getTaskTypes() : null)
+              .setTaskSubTypes(request != null ? request.getTaskSubTypes() : null)
               .setMaxCount(request != null ? request.getMaxCount() : DEFAULT_MAX_COUNT));
 
       return ResponseEntity.ok(new GetTasksInProcessingOrWaitingResponse()
@@ -188,8 +188,8 @@ public class TasksManagementPortController implements ITasksManagementPort, Init
     return callWithAuthentication(() -> {
       ITasksManagementService.GetTasksStuckResponse serviceResponse = tasksManagementService
           .getTasksStuck(new ITasksManagementService.GetTasksStuckRequest()
-              .setTaskType(request != null ? request.getTaskType() : null)
-              .setTaskSubType(request != null ? request.getTaskSubType() : null)
+              .setTaskTypes(request != null ? request.getTaskTypes() : null)
+              .setTaskSubTypes(request != null ? request.getTaskSubTypes() : null)
               .setMaxCount(request != null ? request.getMaxCount() : DEFAULT_MAX_COUNT));
 
       return ResponseEntity.ok(new GetTasksStuckResponse().setTasksStuck(serviceResponse.getTasksStuck().stream().map(taskStuck ->

--- a/tw-tasks-management/src/main/java/com/transferwise/tasks/management/TasksManagementService.java
+++ b/tw-tasks-management/src/main/java/com/transferwise/tasks/management/TasksManagementService.java
@@ -173,7 +173,8 @@ public class TasksManagementService implements ITasksManagementService {
     return entryPointsHelper
         .continueOrCreate(ManagementEntryPointGroups.TW_TASKS_MANAGEMENT, ManagementEntryPointNames.GET_TASKS_IN_PROCESSING_OR_WAITING,
             () -> {
-              List<DaoTask3> tasks = managementTaskDao.getTasksInProcessingOrWaitingStatus(request.getMaxCount(), request.getTaskType(), request.getTaskSubType());
+              List<DaoTask3> tasks = managementTaskDao.getTasksInProcessingOrWaitingStatus(
+                  request.getMaxCount(), request.getTaskType(), request.getTaskSubType());
               return new GetTasksInProcessingOrWaitingResponse().setTasksInProcessingOrWaiting(
                   tasks.stream().map(t -> new GetTasksInProcessingOrWaitingResponse.TaskInProcessingOrWaiting()
                       .setTaskVersionId(new TaskVersionId().setId(t.getId()).setVersion(t.getVersion()))

--- a/tw-tasks-management/src/main/java/com/transferwise/tasks/management/TasksManagementService.java
+++ b/tw-tasks-management/src/main/java/com/transferwise/tasks/management/TasksManagementService.java
@@ -124,7 +124,7 @@ public class TasksManagementService implements ITasksManagementService {
             return response;
           }
 
-          List<DaoTask1> tasksInError = managementTaskDao.getTasksInErrorStatus(request.getMaxCount(), request.getTaskType(), null);
+          List<DaoTask1> tasksInError = managementTaskDao.getTasksInErrorStatus(request.getMaxCount(), List.of(request.getTaskType()), null);
           List<TaskVersionId> taskVersionIdsToResume = tasksInError.stream()
               .filter(t -> t.getType().equals(request.getTaskType()))
               .map(t -> new TaskVersionId().setId(t.getId()).setVersion(t.getVersion()))
@@ -139,7 +139,7 @@ public class TasksManagementService implements ITasksManagementService {
   public GetTasksInErrorResponse getTasksInError(GetTasksInErrorRequest request) {
     return entryPointsHelper
         .continueOrCreate(ManagementEntryPointGroups.TW_TASKS_MANAGEMENT, ManagementEntryPointNames.GET_TASKS_IN_ERROR, () -> {
-          List<DaoTask1> tasks = managementTaskDao.getTasksInErrorStatus(request.getMaxCount(), request.getTaskType(), request.getTaskSubType());
+          List<DaoTask1> tasks = managementTaskDao.getTasksInErrorStatus(request.getMaxCount(), request.getTaskTypes(), request.getTaskSubTypes());
 
           return new GetTasksInErrorResponse().setTasksInError(
               tasks.stream().map(t -> new GetTasksInErrorResponse.TaskInError()
@@ -156,7 +156,7 @@ public class TasksManagementService implements ITasksManagementService {
   public GetTasksStuckResponse getTasksStuck(GetTasksStuckRequest request) {
     return entryPointsHelper
         .continueOrCreate(ManagementEntryPointGroups.TW_TASKS_MANAGEMENT, ManagementEntryPointNames.GET_TASKS_STUCK, () -> {
-          List<DaoTask2> tasks = managementTaskDao.getStuckTasks(request.getMaxCount(), request.getTaskType(), request.getTaskSubType(),
+          List<DaoTask2> tasks = managementTaskDao.getStuckTasks(request.getMaxCount(), request.getTaskTypes(), request.getTaskSubTypes(),
               request.getDelta() == null ? Duration.ofSeconds(10) : request.getDelta());
 
           return new GetTasksStuckResponse().setTasksStuck(
@@ -174,7 +174,7 @@ public class TasksManagementService implements ITasksManagementService {
         .continueOrCreate(ManagementEntryPointGroups.TW_TASKS_MANAGEMENT, ManagementEntryPointNames.GET_TASKS_IN_PROCESSING_OR_WAITING,
             () -> {
               List<DaoTask3> tasks = managementTaskDao.getTasksInProcessingOrWaitingStatus(
-                  request.getMaxCount(), request.getTaskType(), request.getTaskSubType());
+                  request.getMaxCount(), request.getTaskTypes(), request.getTaskSubTypes());
               return new GetTasksInProcessingOrWaitingResponse().setTasksInProcessingOrWaiting(
                   tasks.stream().map(t -> new GetTasksInProcessingOrWaitingResponse.TaskInProcessingOrWaiting()
                       .setTaskVersionId(new TaskVersionId().setId(t.getId()).setVersion(t.getVersion()))

--- a/tw-tasks-management/src/main/java/com/transferwise/tasks/management/TasksManagementService.java
+++ b/tw-tasks-management/src/main/java/com/transferwise/tasks/management/TasksManagementService.java
@@ -17,6 +17,7 @@ import com.transferwise.tasks.management.dao.IManagementTaskDao;
 import com.transferwise.tasks.management.dao.IManagementTaskDao.DaoTask1;
 import com.transferwise.tasks.management.dao.IManagementTaskDao.DaoTask2;
 import com.transferwise.tasks.management.dao.IManagementTaskDao.DaoTask3;
+import com.transferwise.tasks.management.dao.IManagementTaskDao.DaoTaskType;
 import com.transferwise.tasks.utils.LogUtils;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -123,7 +124,7 @@ public class TasksManagementService implements ITasksManagementService {
             return response;
           }
 
-          List<DaoTask1> tasksInError = managementTaskDao.getTasksInErrorStatus(request.getMaxCount());
+          List<DaoTask1> tasksInError = managementTaskDao.getTasksInErrorStatus(request.getMaxCount(), request.getTaskType(), null);
           List<TaskVersionId> taskVersionIdsToResume = tasksInError.stream()
               .filter(t -> t.getType().equals(request.getTaskType()))
               .map(t -> new TaskVersionId().setId(t.getId()).setVersion(t.getVersion()))
@@ -138,7 +139,7 @@ public class TasksManagementService implements ITasksManagementService {
   public GetTasksInErrorResponse getTasksInError(GetTasksInErrorRequest request) {
     return entryPointsHelper
         .continueOrCreate(ManagementEntryPointGroups.TW_TASKS_MANAGEMENT, ManagementEntryPointNames.GET_TASKS_IN_ERROR, () -> {
-          List<DaoTask1> tasks = managementTaskDao.getTasksInErrorStatus(request.getMaxCount());
+          List<DaoTask1> tasks = managementTaskDao.getTasksInErrorStatus(request.getMaxCount(), request.getTaskType(), request.getTaskSubType());
 
           return new GetTasksInErrorResponse().setTasksInError(
               tasks.stream().map(t -> new GetTasksInErrorResponse.TaskInError()
@@ -155,8 +156,8 @@ public class TasksManagementService implements ITasksManagementService {
   public GetTasksStuckResponse getTasksStuck(GetTasksStuckRequest request) {
     return entryPointsHelper
         .continueOrCreate(ManagementEntryPointGroups.TW_TASKS_MANAGEMENT, ManagementEntryPointNames.GET_TASKS_STUCK, () -> {
-          List<DaoTask2> tasks = managementTaskDao.getStuckTasks(request.getMaxCount(), request.getDelta() == null
-              ? Duration.ofSeconds(10) : request.getDelta());
+          List<DaoTask2> tasks = managementTaskDao.getStuckTasks(request.getMaxCount(), request.getTaskType(), request.getTaskSubType(),
+              request.getDelta() == null ? Duration.ofSeconds(10) : request.getDelta());
 
           return new GetTasksStuckResponse().setTasksStuck(
               tasks.stream().map(t -> new GetTasksStuckResponse.TaskStuck()
@@ -172,7 +173,7 @@ public class TasksManagementService implements ITasksManagementService {
     return entryPointsHelper
         .continueOrCreate(ManagementEntryPointGroups.TW_TASKS_MANAGEMENT, ManagementEntryPointNames.GET_TASKS_IN_PROCESSING_OR_WAITING,
             () -> {
-              List<DaoTask3> tasks = managementTaskDao.getTasksInProcessingOrWaitingStatus(request.getMaxCount());
+              List<DaoTask3> tasks = managementTaskDao.getTasksInProcessingOrWaitingStatus(request.getMaxCount(), request.getTaskType(), request.getTaskSubType());
               return new GetTasksInProcessingOrWaitingResponse().setTasksInProcessingOrWaiting(
                   tasks.stream().map(t -> new GetTasksInProcessingOrWaitingResponse.TaskInProcessingOrWaiting()
                       .setTaskVersionId(new TaskVersionId().setId(t.getId()).setVersion(t.getVersion()))
@@ -253,6 +254,17 @@ public class TasksManagementService implements ITasksManagementService {
             }
           }
           return response;
+        });
+  }
+
+  @Override
+  public GetTaskTypesResponse getTaskTypes() {
+    return entryPointsHelper
+        .continueOrCreate(ManagementEntryPointGroups.TW_TASKS_MANAGEMENT, ManagementEntryPointNames.GET_TASKS_TYPES, () -> {
+          List<DaoTaskType> types = managementTaskDao.getTaskTypes();
+          return new GetTaskTypesResponse().setTypes(
+              types.stream().map(t -> new GetTaskTypesResponse.TaskType().setType(t.getType()).setSubTypes(t.getSubTypes()))
+                  .collect(Collectors.toList()));
         });
   }
 }

--- a/tw-tasks-management/src/main/java/com/transferwise/tasks/management/dao/IManagementTaskDao.java
+++ b/tw-tasks-management/src/main/java/com/transferwise/tasks/management/dao/IManagementTaskDao.java
@@ -43,13 +43,22 @@ public interface IManagementTaskDao {
     private ZonedDateTime nextEventTime;
   }
 
-  List<DaoTask1> getTasksInErrorStatus(int maxCount);
+  @Data
+  @Accessors(chain = true)
+  class DaoTaskType {
+    private String type;
+    private List<String> subTypes;
+  }
+
+  List<DaoTask1> getTasksInErrorStatus(int maxCount, String taskType, String taskSubType);
 
   boolean scheduleTaskForImmediateExecution(UUID taskId, long version);
 
-  List<DaoTask2> getStuckTasks(int maxCount, Duration delta);
+  List<DaoTask2> getStuckTasks(int maxCount, String taskType, String taskSubType, Duration delta);
 
-  List<DaoTask3> getTasksInProcessingOrWaitingStatus(int maxCount);
+  List<DaoTask3> getTasksInProcessingOrWaitingStatus(int maxCount, String taskType, String taskSubType);
 
   List<FullTaskRecord> getTasks(List<UUID> uuids);
+
+  List<DaoTaskType> getTaskTypes();
 }

--- a/tw-tasks-management/src/main/java/com/transferwise/tasks/management/dao/IManagementTaskDao.java
+++ b/tw-tasks-management/src/main/java/com/transferwise/tasks/management/dao/IManagementTaskDao.java
@@ -50,13 +50,13 @@ public interface IManagementTaskDao {
     private List<String> subTypes;
   }
 
-  List<DaoTask1> getTasksInErrorStatus(int maxCount, String taskType, String taskSubType);
+  List<DaoTask1> getTasksInErrorStatus(int maxCount, List<String> taskType, List<String> taskSubType);
 
   boolean scheduleTaskForImmediateExecution(UUID taskId, long version);
 
-  List<DaoTask2> getStuckTasks(int maxCount, String taskType, String taskSubType, Duration delta);
+  List<DaoTask2> getStuckTasks(int maxCount, List<String> taskTypes, List<String> taskSubTypes, Duration delta);
 
-  List<DaoTask3> getTasksInProcessingOrWaitingStatus(int maxCount, String taskType, String taskSubType);
+  List<DaoTask3> getTasksInProcessingOrWaitingStatus(int maxCount, List<String> taskTypes, List<String> taskSubTypes);
 
   List<FullTaskRecord> getTasks(List<UUID> uuids);
 

--- a/tw-tasks-management/src/main/java/com/transferwise/tasks/management/dao/JdbcManagementTaskDao.java
+++ b/tw-tasks-management/src/main/java/com/transferwise/tasks/management/dao/JdbcManagementTaskDao.java
@@ -1,5 +1,10 @@
 package com.transferwise.tasks.management.dao;
 
+import static java.util.stream.Collectors.filtering;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.mapping;
+import static java.util.stream.Collectors.toList;
+
 import com.transferwise.common.context.TwContextClockHolder;
 import com.transferwise.tasks.dao.ITaskDaoDataSerializer;
 import com.transferwise.tasks.dao.ITaskDaoDataSerializer.SerializedData;
@@ -24,8 +29,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
-import javax.management.Query;
 import javax.sql.DataSource;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
@@ -33,10 +36,6 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.PreparedStatementSetter;
 import org.springframework.transaction.annotation.Transactional;
 
-import static java.util.stream.Collectors.filtering;
-import static java.util.stream.Collectors.groupingBy;
-import static java.util.stream.Collectors.mapping;
-import static java.util.stream.Collectors.toList;
 
 public class JdbcManagementTaskDao implements IManagementTaskDao {
 
@@ -84,9 +83,16 @@ public class JdbcManagementTaskDao implements IManagementTaskDao {
       QueryBuilder and(String paramName, Op op) {
         this.where += " AND " + paramName;
         switch (op) {
-          case EQUALS: where += "=?"; break;
-          case IN: where += " IN (?)"; break;
-          case LESS_THAN: where += " <?"; break;
+          case IN:
+            where += " IN (?)";
+            break;
+          case LESS_THAN:
+            where += " <?";
+            break;
+          case EQUALS:
+          default:
+            where += "=?";
+            break;
         }
         return this;
       }

--- a/tw-tasks-management/src/main/java/com/transferwise/tasks/management/dao/JdbcManagementTaskDao.java
+++ b/tw-tasks-management/src/main/java/com/transferwise/tasks/management/dao/JdbcManagementTaskDao.java
@@ -10,24 +10,37 @@ import com.transferwise.tasks.domain.TaskStatus;
 import com.transferwise.tasks.helpers.sql.ArgumentPreparedStatementSetter;
 import com.transferwise.tasks.helpers.sql.CacheKey;
 import com.transferwise.tasks.helpers.sql.SqlHelper;
+import com.transferwise.tasks.management.dao.JdbcManagementTaskDao.Queries.QueryBuilder;
+import com.transferwise.tasks.management.dao.JdbcManagementTaskDao.Queries.QueryBuilder.Op;
 import com.transferwise.tasks.utils.TimeUtils;
 import java.sql.Timestamp;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import javax.management.Query;
 import javax.sql.DataSource;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.PreparedStatementSetter;
 import org.springframework.transaction.annotation.Transactional;
 
+import static java.util.stream.Collectors.filtering;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.mapping;
+import static java.util.stream.Collectors.toList;
+
 public class JdbcManagementTaskDao implements IManagementTaskDao {
 
-  private static class Queries {
+  static class Queries {
 
     static final String GET_TASKS = "getTasks";
 
@@ -36,20 +49,72 @@ public class JdbcManagementTaskDao implements IManagementTaskDao {
     final String getStuckTasks;
     final String getTasksInStatus;
     final String getTasks;
+    final String getTaskTypes;
 
     Queries(ITwTaskTables tables) {
       scheduleTaskForImmediateExecution = "update " + tables.getTaskTableIdentifier() + " set status=?"
-          + ",next_event_time=?,state_time=?,time_updated=?,version=? where id=? and version=?";
-      getTasksInErrorStatus = "select id,version,state_time,type,sub_type from " + tables.getTaskTableIdentifier()
-          + " where status='" + TaskStatus.ERROR.name() + "' order by next_event_time desc limit ?";
-      getStuckTasks = "select id,version,next_event_time from " + tables.getTaskTableIdentifier() + " where status=?"
-          + " and next_event_time<? order by next_event_time desc limit ?";
-      getTasksInStatus = "select id,version,state_time,type,sub_type,status,next_event_time from " + tables.getTaskTableIdentifier()
-          + " where status in (?) order by next_event_time desc limit ?";
+          + ",next_event_time=?,state_time=?,time_updated=?,version=?";
+      getTasksInErrorStatus = "select id,version,state_time,type,sub_type from " + tables.getTaskTableIdentifier();
+      getStuckTasks = "select id,version,next_event_time from " + tables.getTaskTableIdentifier();
+      getTasksInStatus = "select id,version,state_time,type,sub_type,status,next_event_time from " + tables.getTaskTableIdentifier();
       getTasks = "select id,type,sub_type,t.data,status,version,processing_tries_count,priority,state_time"
           + ",next_event_time,processing_client_id,d.data_format,d.data"
           + " from " + tables.getTaskTableIdentifier() + " t left join " + tables.getTaskDataTableIdentifier() + " d on t.id = d.task_id"
           + " where t.id in (??)";
+      getTaskTypes = "select distinct type, sub_type from " + tables.getTaskTableIdentifier();
+    }
+
+    static QueryBuilder queryBuilder(String select) {
+      if (select.toLowerCase().contains(" where ")) {
+        throw new IllegalArgumentException("Use and() to build selection criteria");
+      }
+      return new QueryBuilder(select);
+    }
+
+    public static class QueryBuilder {
+      private final String select;
+      private String where;
+      private String orderBy = "";
+      private String limit = "";
+
+      QueryBuilder and(String paramName) {
+        return and(paramName, Op.EQUALS);
+      }
+
+      QueryBuilder and(String paramName, Op op) {
+        this.where += " AND " + paramName;
+        switch (op) {
+          case EQUALS: where += "=?"; break;
+          case IN: where += " IN (?)"; break;
+          case LESS_THAN: where += " <?"; break;
+        }
+        return this;
+      }
+
+      QueryBuilder desc(String orderBy) {
+        this.orderBy = " order by " + orderBy + " desc";
+        return this;
+      }
+
+      QueryBuilder withLimit() {
+        this.limit = " limit ?";
+        return this;
+      }
+
+      String build() {
+        return this.select + this.where + this.orderBy + this.limit;
+      }
+
+      QueryBuilder(String select) {
+        this.select = select;
+        this.where = " WHERE 1=1";
+      }
+
+      enum Op {
+        EQUALS,
+        IN,
+        LESS_THAN
+      }
     }
   }
 
@@ -82,10 +147,21 @@ public class JdbcManagementTaskDao implements IManagementTaskDao {
   }
 
   @Override
-  public List<DaoTask1> getTasksInErrorStatus(int maxCount) {
+  public List<DaoTask1> getTasksInErrorStatus(int maxCount, String taskType, String taskSubType) {
+    QueryBuilder builder = Queries.queryBuilder(queries.getTasksInErrorStatus)
+        .and("status")
+        .desc("next_event_time")
+        .withLimit();
+
+    if (taskType != null) {
+      builder.and("type");
+    }
+    if (taskSubType != null) {
+      builder.and("sub_type");
+    }
     return jdbcTemplate.query(
-        queries.getTasksInErrorStatus,
-        args(maxCount),
+        builder.build(),
+        args(TaskStatus.ERROR.name(), taskType, taskSubType, maxCount),
         (rs, rowNum) ->
             new DaoTask1()
                 .setId(sqlMapper.sqlTaskIdToUuid(rs.getObject(1)))
@@ -99,23 +175,42 @@ public class JdbcManagementTaskDao implements IManagementTaskDao {
   @Override
   @Transactional(rollbackFor = Exception.class)
   public boolean scheduleTaskForImmediateExecution(UUID taskId, long version) {
+    if (taskId == null) {
+      throw new IllegalArgumentException("taskId may not be null");
+    }
     Timestamp now = Timestamp.from(Instant.now(TwContextClockHolder.getClock()));
+    String query = Queries.queryBuilder(queries.scheduleTaskForImmediateExecution)
+        .and("id")
+        .and("version")
+        .build();
     return jdbcTemplate.update(
-        queries.scheduleTaskForImmediateExecution,
+        query,
         args(TaskStatus.WAITING, now, now, now, version + 1, taskId, version)
     ) == 1;
   }
 
   @Override
-  public List<DaoTask2> getStuckTasks(int maxCount, Duration delta) {
+  public List<DaoTask2> getStuckTasks(int maxCount, String taskType, String taskSubType, Duration delta) {
     Timestamp timeThreshold = Timestamp.from(ZonedDateTime.now(TwContextClockHolder.getClock()).toInstant().minus(delta));
 
     List<DaoTask2> stuckTasks = new ArrayList<>();
+    QueryBuilder builder = Queries.queryBuilder(queries.getStuckTasks)
+        .and("status")
+        .and("next_event_time", Op.LESS_THAN)
+        .desc("next_event_time")
+        .withLimit();
+    if (taskType != null) {
+      builder.and("type");
+    }
+    if (taskSubType != null) {
+      builder.and("sub_type");
+    }
+    String query = builder.build();
     for (TaskStatus taskStatus : STUCK_STATUSES) {
       stuckTasks.addAll(
           jdbcTemplate.query(
-              queries.getStuckTasks,
-              args(taskStatus, timeThreshold, maxCount),
+              query,
+              args(taskStatus.name(), timeThreshold, taskType, taskSubType, maxCount),
               (rs, rowNum) ->
                   new DaoTask2()
                       .setId(sqlMapper.sqlTaskIdToUuid(rs.getObject(1)))
@@ -131,13 +226,25 @@ public class JdbcManagementTaskDao implements IManagementTaskDao {
   }
 
   @Override
-  public List<DaoTask3> getTasksInProcessingOrWaitingStatus(int maxCount) {
+  public List<DaoTask3> getTasksInProcessingOrWaitingStatus(int maxCount, String taskType, String taskSubType) {
     List<DaoTask3> result = new ArrayList<>();
+    QueryBuilder builder = Queries.queryBuilder(queries.getTasksInStatus)
+        .and("status")
+        .desc("next_event_time")
+        .withLimit();
+
+    if (taskType != null) {
+      builder.and("type");
+    }
+    if (taskSubType != null) {
+      builder.and("sub_type");
+    }
+    String query = builder.build();
     for (TaskStatus taskStatus : WAITING_AND_PROCESSING_STATUSES) {
       result.addAll(
           jdbcTemplate.query(
-              queries.getTasksInStatus,
-              args(taskStatus, maxCount),
+              query,
+              args(taskStatus, taskType, taskSubType, maxCount),
               (rs, rowNum) ->
                   new DaoTask3()
                       .setId(sqlMapper.sqlTaskIdToUuid(rs.getObject(1)))
@@ -211,7 +318,23 @@ public class JdbcManagementTaskDao implements IManagementTaskDao {
     }
   }
 
+  @Override
+  public List<DaoTaskType> getTaskTypes() {
+    List<Pair<String, String>> types = jdbcTemplate.query(
+        queries.getTaskTypes,
+        (rs, rowNum) -> ImmutablePair.of(rs.getString(1), rs.getString(2)));
+
+    return types.stream()
+        .collect(groupingBy(Pair::getKey, mapping(Pair::getValue, filtering(Objects::nonNull, toList()))))
+        .entrySet()
+        .stream()
+        .map(entry -> new DaoTaskType().setType(entry.getKey()).setSubTypes(entry.getValue().stream().sorted().collect(toList())))
+        .sorted(Comparator.comparing(DaoTaskType::getType))
+        .collect(toList());
+  }
+
   protected PreparedStatementSetter args(Object... args) {
-    return new ArgumentPreparedStatementSetter(sqlMapper::uuidToSqlTaskId, args);
+    Object[] filtered = Arrays.stream(args).filter(Objects::nonNull).toArray();
+    return new ArgumentPreparedStatementSetter(sqlMapper::uuidToSqlTaskId, filtered);
   }
 }


### PR DESCRIPTION
## Context

- Added `taskType` and `taskSubType` parameters to management query endpoints.
- Added `/getTaskTypes` endpoint to retrieve list of registered task types and sub-types

these params and endpoints can be used by `ninjas.transferwise.com/tasks` to improve engineer experience with server-side filtering when supported

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
