### PR TITLE
Address HttpStatus Incompatibility (PAYINP-2233)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### 1.41.1 - 2023/12/19
+### Changed
+- When building a Spring `ResponseEntity` with an explicit status, provide an integer derived from the `HttpStatus` enum, rather than providing the
+  `HttpStatus` directly, to handle binary incompatibility between Spring 5 and 6 causing NoSuchMethod errors when tw-tasks is used with Spring 6
+
 #### 1.41.0 - 2023/11/16
 ### Added
 - Added `taskType` and `taskSubType` parameters to management query endpoints.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.41.0
+version=1.41.1
 org.gradle.internal.http.socketTimeout=120000

--- a/tw-tasks-management/src/main/java/com/transferwise/tasks/management/TasksManagementPortController.java
+++ b/tw-tasks-management/src/main/java/com/transferwise/tasks/management/TasksManagementPortController.java
@@ -217,7 +217,7 @@ public class TasksManagementPortController implements ITasksManagementPort, Init
     final Authentication auth = getAuthenticationIfAllowed(roles);
 
     if (auth == null) {
-      return (T) ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+      return (T) ResponseEntity.status(HttpStatus.FORBIDDEN.value()).build();
     }
 
     return fun.apply(auth);


### PR DESCRIPTION
## Context

When building the forbidden response in the task management controller, when the caller does not have permission to do the operation, use the `ResponseEntity.status()` overload that takes an integer rather than the overload that takes a HttpStatus enum instance.

This addresses an issue whereby when the library is used with Spring 6, which changes the `status` method to take a `HttpStatusCode` interface implementation instead, a `NoSuchMethod` exception is raised. This appears due to the Spring 6 release breaking binary compatibility between Spring 5.

This change should allow the library to continue working in both Spring 5 and Spring 6, without the need for a separate Spring 6 compatible version of the library.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
