### PR TITLE
add filter for querying task types by status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### 1.41.4 - 2024/04/02
+### Changed
+- `/getTaskTypes` endpoint accepts optional query parameter `status` to filter only types of tasks in the particular status(es).
+- Fixed a bug with `taskType` and `taskSubType` filters on query endpoints when multiple values are supplied, where it would consider only one value.
+
 #### 1.41.3 - 2024/02/29
 ### Changed
 * Add compatibility with Spring Boot 3.2.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.41.3
+version=1.41.4
 org.gradle.internal.http.socketTimeout=120000

--- a/tw-tasks-management/src/main/java/com/transferwise/tasks/management/ITasksManagementPort.java
+++ b/tw-tasks-management/src/main/java/com/transferwise/tasks/management/ITasksManagementPort.java
@@ -142,7 +142,7 @@ public interface ITasksManagementPort {
 
   @GetMapping(value = "${tw-tasks.core.base-url:}/v1/twTasks/getTaskTypes", produces = {MediaType.APPLICATION_JSON_VALUE})
   @ResponseBody
-  ResponseEntity<GetTaskTypesResponse> getTaskTypes();
+  ResponseEntity<GetTaskTypesResponse> getTaskTypes(@RequestParam(name = "status", required = false) List<String> status);
 
 
   @Data

--- a/tw-tasks-management/src/main/java/com/transferwise/tasks/management/ITasksManagementService.java
+++ b/tw-tasks-management/src/main/java/com/transferwise/tasks/management/ITasksManagementService.java
@@ -214,7 +214,7 @@ public interface ITasksManagementService {
     }
   }
 
-  GetTaskTypesResponse getTaskTypes();
+  GetTaskTypesResponse getTaskTypes(List<String> status);
 
   @Data
   @Accessors(chain = true)

--- a/tw-tasks-management/src/main/java/com/transferwise/tasks/management/TasksManagementPortController.java
+++ b/tw-tasks-management/src/main/java/com/transferwise/tasks/management/TasksManagementPortController.java
@@ -6,6 +6,7 @@ import com.transferwise.tasks.domain.TaskVersionId;
 import com.transferwise.tasks.management.ITasksManagementPort.GetTaskDataResponse.ResultCode;
 import com.transferwise.tasks.management.ITasksManagementService.GetTaskDataRequest;
 import com.transferwise.tasks.management.ITasksManagementService.GetTaskDataRequest.ContentFormat;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -26,6 +27,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller
 @Slf4j
@@ -199,9 +201,9 @@ public class TasksManagementPortController implements ITasksManagementPort, Init
   }
 
   @Override
-  public ResponseEntity<GetTaskTypesResponse> getTaskTypes() {
+  public ResponseEntity<GetTaskTypesResponse> getTaskTypes(@RequestParam(name = "status", required = false) List<String> status) {
     return callWithAuthentication(() -> {
-      ITasksManagementService.GetTaskTypesResponse serviceResponse = tasksManagementService.getTaskTypes();
+      ITasksManagementService.GetTaskTypesResponse serviceResponse = tasksManagementService.getTaskTypes(status);
 
       return ResponseEntity.ok(new GetTaskTypesResponse().setTypes(serviceResponse.getTypes().stream().map(type ->
           new GetTaskTypesResponse.TaskType().setType(type.getType()).setSubTypes(type.getSubTypes())).collect(Collectors.toList())));

--- a/tw-tasks-management/src/main/java/com/transferwise/tasks/management/TasksManagementService.java
+++ b/tw-tasks-management/src/main/java/com/transferwise/tasks/management/TasksManagementService.java
@@ -259,10 +259,10 @@ public class TasksManagementService implements ITasksManagementService {
   }
 
   @Override
-  public GetTaskTypesResponse getTaskTypes() {
+  public GetTaskTypesResponse getTaskTypes(List<String> status) {
     return entryPointsHelper
         .continueOrCreate(ManagementEntryPointGroups.TW_TASKS_MANAGEMENT, ManagementEntryPointNames.GET_TASKS_TYPES, () -> {
-          List<DaoTaskType> types = managementTaskDao.getTaskTypes();
+          List<DaoTaskType> types = managementTaskDao.getTaskTypes(status);
           return new GetTaskTypesResponse().setTypes(
               types.stream().map(t -> new GetTaskTypesResponse.TaskType().setType(t.getType()).setSubTypes(t.getSubTypes()))
                   .collect(Collectors.toList()));

--- a/tw-tasks-management/src/main/java/com/transferwise/tasks/management/dao/IManagementTaskDao.java
+++ b/tw-tasks-management/src/main/java/com/transferwise/tasks/management/dao/IManagementTaskDao.java
@@ -60,5 +60,5 @@ public interface IManagementTaskDao {
 
   List<FullTaskRecord> getTasks(List<UUID> uuids);
 
-  List<DaoTaskType> getTaskTypes();
+  List<DaoTaskType> getTaskTypes(List<String> status);
 }


### PR DESCRIPTION
## Context

- `/getTaskTypes` endpoint accepts optional query parameter `status` to filter only types of tasks in the particular status(es).
- Fixed a bug with `taskType` and `taskSubType` filters on query endpoints when multiple values are supplied, where it would consider only one value.


## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
