### PR TITLE
Create BeanPostProcessor beans in static methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### 1.41.5 - 2024/04/05
+### Changed
+* Use static methods to create BeanPostProcessors.
+
 #### 1.41.4 - 2024/04/02
 ### Changed
 - `/getTaskTypes` endpoint accepts optional query parameter `status` to filter only types of tasks in the particular status(es).

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.41.4
+version=1.41.5
 org.gradle.internal.http.socketTimeout=120000

--- a/tw-tasks-jobs-spring-boot-starter/src/main/java/com/transferwise/tasks/ext/jobs/autoconfigure/TwTasksExtJobsAutoConfiguration.java
+++ b/tw-tasks-jobs-spring-boot-starter/src/main/java/com/transferwise/tasks/ext/jobs/autoconfigure/TwTasksExtJobsAutoConfiguration.java
@@ -34,7 +34,7 @@ public class TwTasksExtJobsAutoConfiguration {
 
   @Bean
   @ConditionalOnMissingBean(CronJobAnnotationProcessor.class)
-  public CronJobAnnotationProcessor cronJobAnnotationProcessor() {
+  public static CronJobAnnotationProcessor cronJobAnnotationProcessor() {
     return new CronJobAnnotationProcessor();
   }
 }


### PR DESCRIPTION
## Context

Create BeanPostProcessor beans in static methods to avoid the autoconfiguration classes to be processed in bean post-processing phase and logging a warning.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
