### PR TITLE
add configuration property to disable getTaskTypes endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+#### 1.41.6 - 2024/04/17
+### Added
+- `/getTaskTypes` endpoint may be disabled through configuration property `tw-tasks.core.tasks-management.enable-get-task-types: false`. Services with extreme amount of tasks might benefit from this.
+
 #### 1.41.5 - 2024/04/05
 ### Changed
 * Use static methods to create BeanPostProcessors.

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.41.5
+version=1.41.6
 org.gradle.internal.http.socketTimeout=120000

--- a/integration-tests/src/test/java/com/transferwise/tasks/testapp/TasksManagementPortIntTest.java
+++ b/integration-tests/src/test/java/com/transferwise/tasks/testapp/TasksManagementPortIntTest.java
@@ -10,6 +10,7 @@ import com.transferwise.common.context.TwContextClockHolder;
 import com.transferwise.tasks.BaseIntTest;
 import com.transferwise.tasks.ITaskDataSerializer;
 import com.transferwise.tasks.TaskTestBuilder;
+import com.transferwise.tasks.TasksProperties;
 import com.transferwise.tasks.dao.ITaskDao;
 import com.transferwise.tasks.domain.FullTaskRecord;
 import com.transferwise.tasks.domain.TaskStatus;
@@ -45,6 +46,8 @@ public class TasksManagementPortIntTest extends BaseIntTest {
   private ITaskDao taskDao;
   @Autowired
   private ITaskDataSerializer taskDataSerializer;
+  @Autowired
+  private TasksProperties tasksProperties;
 
   @Test
   void erroneousTasksWillBeCorrectlyFound() {
@@ -564,6 +567,18 @@ public class TasksManagementPortIntTest extends BaseIntTest {
     assertEquals("B", types.get(1).getType());
     assertTrue(types.get(0).getSubTypes().isEmpty());
     assertTrue(types.get(1).getSubTypes().isEmpty());
+  }
+
+  @Test
+  void getTaskTypesFailsIfEndpointIsDisabled() {
+    tasksProperties.getTasksManagement().setEnableGetTaskTypes(false);
+    ResponseEntity<GetTaskTypesResponse> response = goodEngineerTemplate().getForEntity(
+        "/v1/twTasks/getTaskTypes?status=ERROR,PROCESSING",
+        GetTaskTypesResponse.class
+    );
+
+    assertEquals(410, response.getStatusCodeValue());
+    tasksProperties.getTasksManagement().setEnableGetTaskTypes(true);
   }
 
   private TestRestTemplate goodEngineerTemplate() {

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/TasksProperties.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/TasksProperties.java
@@ -430,6 +430,11 @@ public class TasksProperties {
     @jakarta.validation.Valid
     private List<TypeSpecificTaskManagement> typeSpecific = Collections.emptyList();
 
+    /**
+     * Services with lots of tasks might cause the endpoint to timeout, service owners may disable it to avoid high db load.
+     **/
+    private boolean enableGetTaskTypes = true;
+
     @Data
     public static class TypeSpecificTaskManagement {
 

--- a/tw-tasks-management/src/main/java/com/transferwise/tasks/management/TasksManagementPortController.java
+++ b/tw-tasks-management/src/main/java/com/transferwise/tasks/management/TasksManagementPortController.java
@@ -202,6 +202,9 @@ public class TasksManagementPortController implements ITasksManagementPort, Init
 
   @Override
   public ResponseEntity<GetTaskTypesResponse> getTaskTypes(@RequestParam(name = "status", required = false) List<String> status) {
+    if (!tasksProperties.getTasksManagement().isEnableGetTaskTypes()) {
+      return ResponseEntity.status(HttpStatus.GONE).build();
+    }
     return callWithAuthentication(() -> {
       ITasksManagementService.GetTaskTypesResponse serviceResponse = tasksManagementService.getTaskTypes(status);
 


### PR DESCRIPTION
## Context

Some services have extreme amount of tasks and the `/getTaskTypes` endpoints may timeout and put stress on the database.
Service owners may now opt out of the endpoint by simply disabling it if they do not wish to add an index to improve the query.
The UI will stop querying for distinct task types (it is ready to expect failures from this endpoint), but server-side filtering will still be possible (just retrieval of possible task types is limited).

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
