### PR TITLE
MERISK-1179: Add ability to reschedule tasks

### DIFF
--- a/integration-tests/src/test/java/com/transferwise/tasks/testapp/TaskReschedulingIntTest.java
+++ b/integration-tests/src/test/java/com/transferwise/tasks/testapp/TaskReschedulingIntTest.java
@@ -1,0 +1,191 @@
+package com.transferwise.tasks.testapp;
+
+import static com.transferwise.tasks.domain.TaskStatus.WAITING;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.transferwise.common.baseutils.UuidUtils;
+import com.transferwise.tasks.BaseIntTest;
+import com.transferwise.tasks.ITaskDataSerializer;
+import com.transferwise.tasks.ITasksService;
+import com.transferwise.tasks.ITasksService.RescheduleTaskResponse.Result;
+import com.transferwise.tasks.dao.ITaskDao;
+import com.transferwise.tasks.domain.Task;
+import com.transferwise.tasks.domain.TaskStatus;
+import com.transferwise.tasks.management.ITasksManagementService;
+import com.transferwise.tasks.test.ITestTasksService;
+import io.micrometer.core.instrument.Counter;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+public class TaskReschedulingIntTest  extends BaseIntTest {
+
+  @Autowired
+  private ITasksService tasksService;
+  @Autowired
+  private ITestTasksService testTasksService;
+  @Autowired
+  private ITaskDataSerializer taskDataSerializer;
+  @Autowired
+  private ITasksManagementService tasksManagementService;
+  @Autowired
+  private ITaskDao taskDao;
+
+  @BeforeEach
+  void setup() {
+    transactionsHelper.withTransaction().asNew().call(() -> {
+      testTasksService.reset();
+      return null;
+    });
+  }
+
+  @Test
+  void taskCanBeSuccessfullyRescheduled() {
+    testTaskHandlerAdapter.setProcessor(resultRegisteringSyncTaskProcessor);
+    UUID taskId = UuidUtils.generatePrefixCombUuid();
+
+    transactionsHelper.withTransaction().asNew().call(() ->
+        tasksService.addTask(new ITasksService.AddTaskRequest()
+            .setTaskId(taskId)
+            .setData(taskDataSerializer.serialize("I want to be rescheduled"))
+            .setType("test").setRunAfterTime(ZonedDateTime.now().plusHours(1)))
+    );
+
+    await().until(() -> !testTasksService.getWaitingTasks("test", null).isEmpty());
+
+    var task = tasksManagementService.getTasksById(
+        new ITasksManagementService.GetTasksByIdRequest().setTaskIds(List.of(taskId))
+    ).getTasks().stream().filter(t -> t.getTaskVersionId().getId().equals(taskId)).findFirst().orElseThrow();
+
+    assertTrue(transactionsHelper.withTransaction().asNew().call(() ->
+        tasksService.rescheduleTask(
+            new ITasksService.RescheduleTaskRequest()
+                .setTaskId(taskId)
+                .setVersion(task.getTaskVersionId().getVersion())
+                .setRunAfterTime(ZonedDateTime.now().minusHours(1))
+        ).getResult() == Result.OK
+    ));
+
+    await().until(() -> testTasksService.getTasks("test", null, WAITING).isEmpty());
+    await().until(() -> resultRegisteringSyncTaskProcessor.getTaskResults().get(taskId) != null);
+    assertEquals(0, getFailedNextEventTimeChangeCount());
+    assertEquals(1, getTaskRescheduledCount());
+  }
+
+  @Test
+  void taskWillNotBeRescheduleIfVersionHasAlreadyChanged() {
+    testTaskHandlerAdapter.setProcessor(resultRegisteringSyncTaskProcessor);
+    final long initialFailedNextEventTimeChangeCount = getFailedNextEventTimeChangeCount();
+    final UUID taskId = UuidUtils.generatePrefixCombUuid();
+
+    transactionsHelper.withTransaction().asNew().call(() ->
+        tasksService.addTask(new ITasksService.AddTaskRequest()
+            .setTaskId(taskId)
+            .setData(taskDataSerializer.serialize("I want to be rescheduled too!"))
+            .setType("test").setRunAfterTime(ZonedDateTime.now().plusHours(1)))
+    );
+
+    await().until(() -> !testTasksService.getWaitingTasks("test", null).isEmpty());
+
+    var task = tasksManagementService.getTasksById(
+        new ITasksManagementService.GetTasksByIdRequest().setTaskIds(List.of(taskId))
+    ).getTasks().stream().filter(t -> t.getTaskVersionId().getId().equals(taskId)).findFirst().orElseThrow();
+
+    assertFalse(
+        transactionsHelper.withTransaction().asNew().call(() ->
+            tasksService.rescheduleTask(
+                new ITasksService.RescheduleTaskRequest()
+                    .setTaskId(taskId)
+                    .setVersion(task.getTaskVersionId().getVersion() - 1)
+                    .setRunAfterTime(ZonedDateTime.now().plusHours(2))
+            ).getResult() == Result.OK
+        )
+    );
+    assertEquals(initialFailedNextEventTimeChangeCount + 1, getFailedNextEventTimeChangeCount());
+    assertEquals(0, getTaskRescheduledCount());
+  }
+
+  @ParameterizedTest
+  @EnumSource(value = TaskStatus.class,
+      names = {"WAITING"},
+      mode = EnumSource.Mode.EXCLUDE)
+  void taskWillNotBeRescheduleIfNotWaiting(TaskStatus status) {
+    testTaskHandlerAdapter.setProcessor(resultRegisteringSyncTaskProcessor);
+    final long initialFailedNextEventTimeChangeCount = getFailedNextEventTimeChangeCount();
+    final UUID taskId = UuidUtils.generatePrefixCombUuid();
+
+    transactionsHelper.withTransaction().asNew().call(() ->
+        tasksService.addTask(new ITasksService.AddTaskRequest()
+            .setTaskId(taskId)
+            .setData(taskDataSerializer.serialize("I do not want to be rescheduled!"))
+            .setType("test").setRunAfterTime(ZonedDateTime.now().plusHours(2)))
+    );
+
+    await().until(() -> !testTasksService.getWaitingTasks("test", null).isEmpty());
+    List<Task> tasks = testTasksService.getWaitingTasks("test", null);
+    Task task = tasks.stream().filter(t -> t.getId().equals(taskId)).findFirst().orElseThrow();
+
+    transactionsHelper.withTransaction().asNew().call(() ->
+        tasksService.resumeTask(new ITasksService.ResumeTaskRequest().setTaskId(taskId).setVersion(task.getVersion()))
+    );
+
+    await().until(() -> testTasksService.getWaitingTasks("test", null).isEmpty());
+
+    var updateTask = tasksManagementService.getTasksById(
+        new ITasksManagementService.GetTasksByIdRequest().setTaskIds(List.of(taskId))
+    ).getTasks().stream().filter(t -> t.getTaskVersionId().getId().equals(taskId)).findFirst().orElseThrow();
+
+    taskDao.setStatus(taskId, status, updateTask.getTaskVersionId().getVersion());
+
+    var finalTask = tasksManagementService.getTasksById(
+        new ITasksManagementService.GetTasksByIdRequest().setTaskIds(List.of(taskId))
+    ).getTasks().stream().filter(t -> t.getTaskVersionId().getId().equals(taskId)).findFirst().orElseThrow();
+
+    assertFalse(
+        transactionsHelper.withTransaction().asNew().call(() ->
+            tasksService.rescheduleTask(
+                new ITasksService.RescheduleTaskRequest()
+                    .setTaskId(taskId)
+                    .setVersion(finalTask.getTaskVersionId().getVersion())
+                    .setRunAfterTime(ZonedDateTime.now().plusHours(2))
+            ).getResult() == Result.OK
+        )
+    );
+    assertEquals(initialFailedNextEventTimeChangeCount + 1, getFailedNextEventTimeChangeCount());
+    assertEquals(0, getTaskRescheduledCount());
+  }
+
+  private long getFailedNextEventTimeChangeCount() {
+    Counter counter = meterRegistry.find("twTasks.tasks.failedNextEventTimeChangeCount").tags(
+        "taskType", "test"
+    ).counter();
+
+    if (counter == null) {
+      return 0;
+    } else {
+      return (long) counter.count();
+    }
+  }
+
+  private long getTaskRescheduledCount() {
+    Counter counter = meterRegistry.find("twTasks.tasks.rescheduledCount").tags(
+        "taskType", "test"
+    ).counter();
+
+    if (counter == null) {
+      return 0;
+    } else {
+      return (long) counter.count();
+    }
+  }
+}

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/ITasksService.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/ITasksService.java
@@ -83,6 +83,27 @@ public interface ITasksService {
     private boolean force;
   }
 
+  RescheduleTaskResponse rescheduleTask(RescheduleTaskRequest request);
+
+  @Data
+  @Accessors(chain = true)
+  class RescheduleTaskRequest {
+    private UUID taskId;
+    private long version;
+    private ZonedDateTime runAfterTime;
+  }
+
+  @Data
+  @Accessors(chain = true)
+  class RescheduleTaskResponse {
+    private UUID taskId;
+    private Result result;
+
+    public enum Result {
+      OK, NOT_FOUND, NOT_ALLOWED, FAILED
+    }
+  }
+
   void startTasksProcessing(String bucketId);
 
   Future<Void> stopTasksProcessing(String bucketId);

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/dao/ITaskDao.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/dao/ITaskDao.java
@@ -116,6 +116,8 @@ public interface ITaskDao {
 
   boolean setStatus(UUID taskId, TaskStatus status, long version);
 
+  boolean setNextEventTime(UUID taskId, ZonedDateTime nextEventTime, long version, String state);
+
   boolean markAsSubmitted(UUID taskId, long version, ZonedDateTime maxStuckTime);
 
   Long getTaskVersion(UUID id);

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/dao/JdbcTaskDao.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/dao/JdbcTaskDao.java
@@ -99,6 +99,7 @@ public abstract class JdbcTaskDao implements ITaskDao, InitializingBean {
   protected String grabForProcessingWithStatusAssertionSql;
   protected String grabForProcessingSql;
   protected String setStatusSql;
+  protected String setNextEventTimeSql;
   protected String getStuckTasksSql;
   protected String prepareStuckOnProcessingTaskForResumingSql;
   protected String prepareStuckOnProcessingTaskForResumingSql1;
@@ -157,6 +158,7 @@ public abstract class JdbcTaskDao implements ITaskDao, InitializingBean {
         + ",processing_start_time=?,next_event_time=?,processing_tries_count=processing_tries_count+1"
         + ",state_time=?,time_updated=?,version=? where id=? and version=?";
     setStatusSql = "update " + taskTable + " set status=?,next_event_time=?,state_time=?,time_updated=?,version=? where id=? and version=?";
+    setNextEventTimeSql = "update " + taskTable + " set next_event_time=?,state_time=?,time_updated=?,version=? where id=? and version=? and status=?";
     getStuckTasksSql = "select id,version,type,priority,status from " + taskTable + " where status=?"
         + " and next_event_time<? order by next_event_time limit ?";
     prepareStuckOnProcessingTaskForResumingSql =
@@ -319,6 +321,14 @@ public abstract class JdbcTaskDao implements ITaskDao, InitializingBean {
   public boolean setStatus(UUID taskId, TaskStatus status, long version) {
     Timestamp now = Timestamp.from(Instant.now(TwContextClockHolder.getClock()));
     int updatedCount = jdbcTemplate.update(setStatusSql, args(status, now, now, now, version + 1, taskId, version));
+    return updatedCount == 1;
+  }
+
+  @Override
+  @Transactional(rollbackFor = Exception.class)
+  public boolean setNextEventTime(UUID taskId, ZonedDateTime nextEventTime, long version, String status) {
+    Timestamp now = Timestamp.from(Instant.now(TwContextClockHolder.getClock()));
+    int updatedCount = jdbcTemplate.update(setNextEventTimeSql, args(nextEventTime, now, now, version + 1, taskId, version, status));
     return updatedCount == 1;
   }
 

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/entrypoints/EntryPointsNames.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/entrypoints/EntryPointsNames.java
@@ -16,6 +16,7 @@ public final class EntryPointsNames {
   public static final String RESUME_TASK = "resumeTask";
   public static final String ASYNC_HANDLE_SUCCESS = "asyncHandleSuccess";
   public static final String ASYNC_HANDLE_FAIL = "asyncHandleFail";
+  public static final String RESCHEDULE_TASK = "rescheduleTask";
 
   private EntryPointsNames() {
     throw new AssertionError();

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/helpers/CoreMetricsTemplate.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/helpers/CoreMetricsTemplate.java
@@ -51,6 +51,8 @@ public class CoreMetricsTemplate implements ICoreMetricsTemplate {
   private static final String METRIC_TASKS_RETRIES_COUNT = METRIC_PREFIX + "tasks.retriesCount";
   private static final String METRIC_TASKS_RESUMINGS_COUNT = METRIC_PREFIX + "tasks.resumingsCount";
   private static final String METRIC_TASKS_MARKED_AS_FAILED_COUNT = METRIC_PREFIX + "tasks.markedAsFailedCount";
+  private static final String METRIC_TASKS_RESCHEDULED_COUNT = METRIC_PREFIX + "tasks.rescheduledCount";
+  private static final String METRIC_TASKS_FAILED_NEXT_EVENT_TIME_CHANGE_COUNT = METRIC_PREFIX + "tasks.failedNextEventTimeChangeCount";
   private static final String METRIC_TASKS_ADDINGS_COUNT = METRIC_PREFIX + "task.addings.count";
   private static final String METRIC_TASKS_SERVICE_IN_PROGRESS_TRIGGERINGS_COUNT = METRIC_PREFIX + "tasksService.inProgressTriggeringsCount";
   private static final String METRIC_TASKS_SERVICE_ACTIVE_TRIGGERINGS_COUNT = METRIC_PREFIX + "tasksService.activeTriggeringsCount";
@@ -95,6 +97,8 @@ public class CoreMetricsTemplate implements ICoreMetricsTemplate {
   private static final String TAG_PROCESSING_RESULT = "processingResult";
   private static final String TAG_FROM_STATUS = "fromStatus";
   private static final String TAG_TO_STATUS = "toStatus";
+  private static final String TAG_FROM_NEXT_EVENT_TIME = "fromNextEventTime";
+  private static final String TAG_TO_NEXT_EVENT_TIME = "toNextEventTime";
   private static final String TAG_TASK_STATUS = "taskStatus";
   private static final String TAG_BUCKET_ID = "bucketId";
   private static final String TAG_SYNC = "sync";
@@ -158,6 +162,19 @@ public class CoreMetricsTemplate implements ICoreMetricsTemplate {
   public void registerFailedStatusChange(String taskType, String fromStatus, TaskStatus toStatus) {
     meterCache.counter(METRIC_TASKS_FAILED_STATUS_CHANGE_COUNT, TagsSet.of(TAG_TASK_TYPE, taskType,
             TAG_FROM_STATUS, fromStatus, TAG_TO_STATUS, toStatus.name()))
+        .increment();
+  }
+
+  @Override
+  public void registerTaskRescheduled(String bucketId, String taskType) {
+    meterCache.counter(METRIC_TASKS_RESCHEDULED_COUNT, TagsSet.of(TAG_BUCKET_ID, resolveBucketId(bucketId), TAG_TASK_TYPE, taskType))
+        .increment();
+  }
+
+  @Override
+  public void registerFailedNextEventTimeChange(String taskType, ZonedDateTime fromNextEventTime, ZonedDateTime toNextEventTime) {
+    meterCache.counter(METRIC_TASKS_FAILED_NEXT_EVENT_TIME_CHANGE_COUNT, TagsSet.of(TAG_TASK_TYPE, taskType,
+            TAG_FROM_NEXT_EVENT_TIME, fromNextEventTime.toString(), TAG_TO_NEXT_EVENT_TIME, toNextEventTime.toString()))
         .increment();
   }
 

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/helpers/ICoreMetricsTemplate.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/helpers/ICoreMetricsTemplate.java
@@ -31,6 +31,8 @@ public interface ICoreMetricsTemplate {
 
   void registerTaskMarkedAsFailed(String bucketId, String taskType);
 
+  void registerTaskRescheduled(String bucketId, String taskType);
+
   void registerDuplicateTask(String taskType, boolean expected);
 
   void registerScheduledTaskResuming(String taskType);
@@ -44,6 +46,8 @@ public interface ICoreMetricsTemplate {
   void registerStuckTaskMarkedAsError(@Nonnull String taskType, @Nonnull StuckDetectionSource stuckDetectionSource);
 
   void registerFailedStatusChange(String taskType, String fromStatus, TaskStatus toStatus);
+
+  void registerFailedNextEventTimeChange(String taskType, ZonedDateTime fromNextEventTime, ZonedDateTime toNextEventTime);
 
   void registerTaskGrabbingResponse(String bucketId, String type, int priority, ProcessTaskResponse processTaskResponse);
 


### PR DESCRIPTION
## Context

**Use case:**
We are running settlement tasks on tw-tasks. Each time a payment is created in **acquiring-payments** we also create an initiate settlement task scheduled for a time Y based on **acquiring-risk** generated time X (it could be T+X+Y or T+Y where Y >= X - not super important to the conversation).

However, now, we need to be able to flexibly change X in **acquiring-risk**: e.g., before cst could settle in T+2 days but we now want them to settle in T+7 days. This would apply to existing pending payments for the cst for whom tw-task initiate settlement was already created (new payments would have a new time automatically).

So, we want to be able to update scheduled run time for the existing tw-task.

**Solution**: Add reschedule to tasksService. Add metrics and tests.
We only want to be able to reschedule tasks in WAITING state using the taskId and versionId.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
