### PR TITLE
MERISK-1244: Add Get Task to extract task by id in tasksService

### DIFF
--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/ITasksService.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/ITasksService.java
@@ -1,5 +1,7 @@
 package com.transferwise.tasks;
 
+import com.transferwise.tasks.ITasksService.AddTaskResponse.Result;
+import com.transferwise.tasks.domain.TaskStatus;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.time.Duration;
 import java.time.ZonedDateTime;
@@ -107,6 +109,32 @@ public interface ITasksService {
     public enum Result {
       OK, NOT_FOUND, NOT_ALLOWED, FAILED
     }
+  }
+
+  GetTaskResponse getTask(GetTaskRequest request);
+
+  @Data
+  @Accessors(chain = true)
+  class GetTaskRequest {
+    private UUID taskId;
+  }
+
+  @Data
+  @Accessors(chain = true)
+  class GetTaskResponse {
+    private UUID taskId;
+    private String type;
+    private long version;
+    private Integer priority;
+    private String status;
+    private ZonedDateTime nextEventTime;
+
+    private Result result;
+
+    public enum Result {
+      OK, NOT_FOUND
+    }
+
   }
 
   void startTasksProcessing(String bucketId);

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/entrypoints/EntryPointsNames.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/entrypoints/EntryPointsNames.java
@@ -17,6 +17,7 @@ public final class EntryPointsNames {
   public static final String ASYNC_HANDLE_SUCCESS = "asyncHandleSuccess";
   public static final String ASYNC_HANDLE_FAIL = "asyncHandleFail";
   public static final String RESCHEDULE_TASK = "rescheduleTask";
+  public static final String GET_TASK = "getTask";
 
   private EntryPointsNames() {
     throw new AssertionError();


### PR DESCRIPTION
## Context

We want to be able to reschedule tasks - merged PR [here](https://github.com/transferwise/tw-tasks-executor/pull/199)
For this, we need to send a request containing version id. However, rn the only option for extracting is using ITasksManagementService. This is not the best practice.

Adding GetTask to be able to find task by its id and get it version + additional metadata for verification (e.g., we could check if the task will run in the next X min -> we don't want to reschedule it) 

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
