### PR TITLE
Add Java17 container to build job in GHA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,6 +125,8 @@ jobs:
 
   build:
     name: "Build and Test"
+    container:
+      image: azul/zulu-openjdk:17
     runs-on:
       - ubuntu-latest
     needs: matrix_build

--- a/build.common.gradle
+++ b/build.common.gradle
@@ -91,13 +91,10 @@ dependencies {
 }
 
 java {
-    if (springBootVersion.startsWith("2.")) {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
-    } else {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
+
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
+
     withSourcesJar()
     withJavadocJar()
 }
@@ -118,18 +115,9 @@ compileJava {
     options.compilerArgs << '-Xlint:-processing'
 }
 
-compileTestJava {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
-    javaCompiler = javaToolchains.compilerFor {
-        languageVersion = JavaLanguageVersion.of(17)
-    }
-}
 
 test {
-    javaLauncher = javaToolchains.launcherFor {
-        languageVersion = JavaLanguageVersion.of(17)
-    }
+
 
     testLogging {
         events TestLogEvent.STARTED, TestLogEvent.FAILED, TestLogEvent.SKIPPED, TestLogEvent.PASSED,


### PR DESCRIPTION
## Context

Add Java17 container to build job in GHA because it was defaulting to jdk11

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
