### PR TITLE
Restoring Spring 4 compatibly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Restoring Spring 4 compatibly.
+
+## 1.45.0 - 2024/10/30
+
+### Changed
+
 - Context switches are reduced.
 - MDC values are cleared more aggressively.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.45.0
+version=1.45.1
 org.gradle.internal.http.socketTimeout=120000

--- a/tw-tasks-management/src/main/java/com/transferwise/tasks/management/TasksManagementPortController.java
+++ b/tw-tasks-management/src/main/java/com/transferwise/tasks/management/TasksManagementPortController.java
@@ -18,7 +18,6 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.core.Authentication;
@@ -203,7 +202,7 @@ public class TasksManagementPortController implements ITasksManagementPort, Init
   @Override
   public ResponseEntity<GetTaskTypesResponse> getTaskTypes(@RequestParam(name = "status", required = false) List<String> status) {
     if (!tasksProperties.getTasksManagement().isEnableGetTaskTypes()) {
-      return ResponseEntity.status(HttpStatus.GONE).build();
+      return ResponseEntity.status(410).build();
     }
     return callWithAuthentication(() -> {
       ITasksManagementService.GetTaskTypesResponse serviceResponse = tasksManagementService.getTaskTypes(status);
@@ -222,7 +221,7 @@ public class TasksManagementPortController implements ITasksManagementPort, Init
     final Authentication auth = getAuthenticationIfAllowed(roles);
 
     if (auth == null) {
-      return (T) ResponseEntity.status(HttpStatus.FORBIDDEN.value()).build();
+      return (T) ResponseEntity.status(403).build();
     }
 
     return fun.apply(auth);


### PR DESCRIPTION
## Context

In Spring 4 we started to get an error that HttpStatusCode does not exist.

Restoring Spring 4 compatibly.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
