### PR TITLE
Update guidance on alerting configuration

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -80,13 +80,25 @@ Write a port-level integration spec.
 Profit!
 
 ##### In Production you want to enable alerts
+
+In your staging and/or production kubernetes manifests add the global alert:
+
+Just replace the "YOUR_*" placeholders below.
+
 ```yaml
-tw-incidents:
-  victorops:
-    enabled: true
-    notify-base-url: https://alert.victorops.com/integrations/generic/12345678/alert/
-    routing-key: my-fancy-team
-    api-token: my api token that comes after the "/alert/" bit in the Victorops URL to notify
+prometheus:
+  globalAlerts:
+    tooManyTwTasksInErrorState:
+      name: tooManyTwTasksInErrorState
+      summary: Number of TwTasks in ERROR state.
+      description: Task has {{ $value }} errors. There must be 0 tasks in ERROR state. Investigate the problem and retry or mark as FAILED here - https://ninjas.transferwise.com/tasks/?service=YOUR_SERVICE_NAME
+      expr: |
+        sum (twTasks_health_tasksInErrorCountPerType{service="YOUR_SERVICE_NAME"}) > 0
+      severity: warning
+      repeatInterval: 6h
+      runbookURL: YOUR_RUN_BOOK_URL
+      slackChannel: '#YOUR_SLACK_CHANNEL'
+      dashboardURL: https://dashboards.tw.ee/d/6cf10e05-ed6e-4f91-9f68-5ca1f97a83d7/tw-tasks?var-service=YOUR_SERVICE_NAME
 ```
 
 ## Additional Configuration

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -87,6 +87,7 @@ Just replace the "YOUR_*" placeholders below.
 
 ```yaml
 prometheus:
+  enabled: true
   globalAlerts:
     tooManyTwTasksInErrorState:
       name: tooManyTwTasksInErrorState


### PR DESCRIPTION
## Context

Current docs suggest using tw-incidents for alerts.
Searching through the conversations I can see that this [is a deprecated approach](https://wise.slack.com/archives/C7P9L0B6Z/p1703091335268209?thread_ts=1703090507.329499&cid=C7P9L0B6Z) and k8s-manifests should be used instead.

## Checklist
- [X] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
