### PR TITLE
Swallow malformed messages on trigger bucket topics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.48.2 - 2024/12/20
+
+### Changed
+
+- Fixed an issue where a malformed message published to a trigger topic would cause task processing to become stuck.
+
 ## 1.48.1 - 2024/12/20
 
 ### Changed

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.48.1
+version=1.48.2
 org.gradle.internal.http.socketTimeout=120000


### PR DESCRIPTION
## Context
At the moment, we're vulnerable to poison pill attacks on our trigger bucket topics (i.e. `twTasks.{service-name}.executeTask.{bucket-name}`).

This issue will be resolved by detecting malformed messages when deserialising to JSON, and in these cases we will just log the error (including topic-partition and offset so that the issue can be looked into) but then continue processing rather than getting stuck in a retry-loop.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
