### PR TITLE
Allow to init only specific jobs in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.47.0 - 2024/12/13
+
+### Added
+
+- Added `resetAndInitialize(Collection<IJob> jobs)` method to `ITestJobsService` to allow to init only specific jobs in tests
+
 # 1.46.1 - 2024/12/04
 
 ### Changed

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.46.1
+version=1.47.0
 org.gradle.internal.http.socketTimeout=120000

--- a/integration-tests/src/test/java/com/transferwise/tasks/ext/jobs/JobsIntTest.java
+++ b/integration-tests/src/test/java/com/transferwise/tasks/ext/jobs/JobsIntTest.java
@@ -16,6 +16,7 @@ import com.transferwise.tasks.impl.jobs.interfaces.IJob;
 import com.transferwise.tasks.impl.jobs.test.ITestJobsService;
 import java.time.Duration;
 import java.time.ZonedDateTime;
+import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
@@ -112,6 +113,23 @@ class JobsIntTest extends BaseIntTest {
 
     await().until(() -> testJobsService.hasFinished(handle));
     assertThat(job.executionsCount).isEqualTo(1);
+  }
+
+  @Test
+  void onlySelectedJobsWillExecute() {
+    JobC job = new JobC();
+    testJobsService.resetAndInitialize(List.of(job));
+
+    // manually triggered job is initialized and executed
+    assertThat(job.executionsCount).isZero();
+
+    ITestJobsService.ExecuteAsyncHandle handle = testJobsService.executeAsync(job);
+
+    await().until(() -> testJobsService.hasFinished(handle));
+    assertThat(job.executionsCount).isEqualTo(1);
+
+    // other did not initialize
+    assertThat(testTasksService.getTasks("TaskJob|JobA", null)).isEmpty();
   }
 
   private <T extends IJob> T registerJobBean(T job) {

--- a/tw-tasks-jobs-test/src/main/java/com/transferwise/tasks/impl/jobs/test/ITestJobsService.java
+++ b/tw-tasks-jobs-test/src/main/java/com/transferwise/tasks/impl/jobs/test/ITestJobsService.java
@@ -3,6 +3,7 @@ package com.transferwise.tasks.impl.jobs.test;
 import com.transferwise.tasks.domain.ITaskVersionId;
 import com.transferwise.tasks.impl.jobs.interfaces.IJob;
 import com.transferwise.tasks.impl.jobs.interfaces.IJobsService;
+import java.util.Collection;
 import lombok.Data;
 import lombok.experimental.Accessors;
 
@@ -12,7 +13,19 @@ public interface ITestJobsService extends IJobsService {
 
   boolean hasFinished(ExecuteAsyncHandle handle);
 
+  /**
+   * Clear all existing jobs and related tw-tasks, and initialize them again (if JobsProperties.autoInitialize is true).
+   */
   void reset();
+
+  /**
+   * Clear all existing jobs and related tw-tasks and initialize with the provided jobs.
+   * Most likely it would be useful when `JobsProperties.autoInitialize` is false,
+   * when only specific jobs are needed to be initialized for the test, so that other jobs won't run.
+   *
+   * @param jobs jobs to initialize (register and create related tw-tasks)
+   */
+  void resetAndInitialize(Collection<IJob> jobs);
 
   @Data
   @Accessors(chain = true)

--- a/tw-tasks-jobs-test/src/main/java/com/transferwise/tasks/impl/jobs/test/TestJobsService.java
+++ b/tw-tasks-jobs-test/src/main/java/com/transferwise/tasks/impl/jobs/test/TestJobsService.java
@@ -9,6 +9,7 @@ import com.transferwise.tasks.domain.TaskVersionId;
 import com.transferwise.tasks.impl.jobs.JobsService;
 import com.transferwise.tasks.impl.jobs.interfaces.IJob;
 import com.transferwise.tasks.test.ITestTasksService;
+import java.util.Collection;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -57,12 +58,19 @@ public class TestJobsService extends JobsService implements ITestJobsService {
 
   @Override
   public void reset() {
-    transactionsHelper.withTransaction().asNew().call(() -> {
+    transactionsHelper.withTransaction().run(() -> {
       testTasksService.reset();
       if (jobsProperties.isAutoInitialize()) {
         initJobs(true);
       }
-      return null;
+    });
+  }
+
+  @Override
+  public void resetAndInitialize(Collection<IJob> jobs) {
+    transactionsHelper.withTransaction().run(() -> {
+      testTasksService.reset();
+      initJobs(true, jobs);
     });
   }
 }


### PR DESCRIPTION
## Context

Allow to init only specific jobs in tests. This is useful when we want to test only one specific (or a few) job in the test, and others jobs should not run randomly in the background, creating flaky tests.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
