### PR TITLE
initialise jobs in new transaction in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.48.1 - 2024/12/20
+
+### Changed
+
+- Fixed a lock timeout on update queries in tests, when running integration tests in a Transaction.
+  - introduced by 1.47.0
+
 ## 1.48.0 - 2024/12/13
 
 ### Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.48.0
+version=1.48.1
 org.gradle.internal.http.socketTimeout=120000

--- a/tw-tasks-jobs-test/src/main/java/com/transferwise/tasks/impl/jobs/test/TestJobsService.java
+++ b/tw-tasks-jobs-test/src/main/java/com/transferwise/tasks/impl/jobs/test/TestJobsService.java
@@ -58,7 +58,7 @@ public class TestJobsService extends JobsService implements ITestJobsService {
 
   @Override
   public void reset() {
-    transactionsHelper.withTransaction().run(() -> {
+    transactionsHelper.withTransaction().asNew().run(() -> {
       testTasksService.reset();
       if (jobsProperties.isAutoInitialize()) {
         initJobs(true);
@@ -68,7 +68,7 @@ public class TestJobsService extends JobsService implements ITestJobsService {
 
   @Override
   public void resetAndInitialize(Collection<IJob> jobs) {
-    transactionsHelper.withTransaction().run(() -> {
+    transactionsHelper.withTransaction().asNew().run(() -> {
       testTasksService.reset();
       initJobs(true, jobs);
     });


### PR DESCRIPTION
## Context

<!-- Why is this PR necessary? If available, include links to a JIRA ticket or other relevant documentation. -->

- Revert back to init jobs in tests in a new transaction. 

Previous change caused tests to fail when tests are wrapped around a Transaction. [example](https://github.com/transferwise/payout-service/blob/master/core/src/test/java/com/transferwise/payout/processing/test/utils/BaseTestEnvironment.java#L50).

payout-service need to move away from that, but its not a straightforward migration.

```
org.springframework.jdbc.UncategorizedSQLException: PreparedStatementCallback; uncategorized SQLException for SQL [update `tw_task` set status=?,next_event_time=?,state_time=?,time_updated=?,version=? where id=? and version=?]; SQL state [HY000]; error code [1205]; (conn=56) Lock wait timeout exceeded; try restarting transaction
	at app//org.springframework.jdbc.core.JdbcTemplate.translateException(JdbcTemplate.java:1549)
	at app//org.springframework.jdbc.core.JdbcTemplate.execute(JdbcTemplate.java:677)
	at app//org.springframework.jdbc.core.JdbcTemplate.update(JdbcTemplate.java:970)
	at app//org.springframework.jdbc.core.JdbcTemplate.update(JdbcTemplate.java:1014)
	at app//com.transferwise.tasks.dao.JdbcTaskDao.markAsSubmitted(JdbcTaskDao.java:404)
	at app//org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:355)
	at app//org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:196)
	at app//org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163)
	at app//org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:768)
	at app//org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:379)
	at app//org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:119)
	at app//org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:184)
	at app//org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:768)
	at app//org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:720)
	at app//com.transferwise.tasks.TasksService.lambda$resumeTask$3(TasksService.java:178)
	at app//com.transferwise.common.context.DefaultUnitOfWorkManager$DefaultBuilder.lambda$toContext$0(DefaultUnitOfWorkManager.java:160)
	at app//com.transferwise.common.context.TwContext.lambda$getWrappedSupplier$2(TwContext.java:257)
	at app//com.transferwise.common.context.TwContext.executeWithInterceptors(TwContext.java:304)
	at app//com.transferwise.common.context.TwContext.lambda$executeWithInterceptors$4(TwContext.java:301)
	at app//com.transferwise.observability.base.internal.tracing.TraceInitializingExecutionInterceptor.intercept(TraceInitializingExecutionInterceptor.java:41)
	at app//com.transferwise.common.context.TwContext.executeWithInterceptors(TwContext.java:301)
	at app//com.transferwise.common.context.TwContext.lambda$executeWithInterceptors$4(TwContext.java:301)
	at app//com.transferwise.common.entrypoints.executionstatistics.ExecutionStatisticsEntryPointInterceptor.intercept(ExecutionStatisticsEntryPointInterceptor.java:32)
	at app//com.transferwise.common.context.TwContext.executeWithInterceptors(TwContext.java:301)
	at app//com.transferwise.common.context.TwContext.lambda$executeWithInterceptors$4(TwContext.java:301)
	at app//com.transferwise.common.entrypoints.databaseaccessstatistics.DatabaseAccessStatisticsEntryPointInterceptor.intercept(DatabaseAccessStatisticsEntryPointInterceptor.java:46)
	at app//com.transferwise.common.context.TwContext.executeWithInterceptors(TwContext.java:301)
	at app//com.transferwise.common.context.TwContext.lambda$executeWithInterceptors$4(TwContext.java:301)
	at app//com.transferwise.common.context.TwContextUniqueEntryPointsLimitingInterceptor.intercept(TwContextUniqueEntryPointsLimitingInterceptor.java:73)
	at app//com.transferwise.common.context.TwContext.executeWithInterceptors(TwContext.java:301)
	at app//com.transferwise.common.context.TwContext.lambda$executeWithInterceptors$4(TwContext.java:301)
	at app//com.transferwise.common.context.MdcRestoringEntryPointInterceptor.intercept(MdcRestoringEntryPointInterceptor.java:18)
	at app//com.transferwise.common.context.TwContext.executeWithInterceptors(TwContext.java:301)
	at app//com.transferwise.common.context.TwContext.lambda$executeWithInterceptors$4(TwContext.java:301)
	at app//com.transferwise.payout.processing.core.config.MdcCleaningEntryPointInterceptor.intercept(MdcCleaningEntryPointInterceptor.java:19)
	at app//com.transferwise.common.context.TwContext.executeWithInterceptors(TwContext.java:301)
	at app//com.transferwise.common.context.TwContext.executeWithInterceptors(TwContext.java:294)
	at app//com.transferwise.common.context.TwContext.execute(TwContext.java:275)
	at app//com.transferwise.tasks.entrypoints.EntryPointsService.createEntrypoint(EntryPointsService.java:27)
	at app//com.transferwise.tasks.entrypoints.EntryPointsService.continueOrCreate(EntryPointsService.java:22)
	at app//com.transferwise.tasks.TasksService.resumeTask(TasksService.java:155)
	at app//org.springframework.aop.support.AopUtils.invokeJoinpointUsingReflection(AopUtils.java:355)
	at app//org.springframework.aop.framework.ReflectiveMethodInvocation.invokeJoinpoint(ReflectiveMethodInvocation.java:196)
	at app//org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:163)
	at app//org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:768)
	at app//org.springframework.transaction.interceptor.TransactionAspectSupport.invokeWithinTransaction(TransactionAspectSupport.java:379)
	at app//org.springframework.transaction.interceptor.TransactionInterceptor.invoke(TransactionInterceptor.java:119)
	at app//org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:184)
	at app//org.springframework.aop.framework.CglibAopProxy$CglibMethodInvocation.proceed(CglibAopProxy.java:768)
	at app//org.springframework.aop.framework.CglibAopProxy$DynamicAdvisedInterceptor.intercept(CglibAopProxy.java:720)
	at app//com.transferwise.tasks.impl.jobs.test.TestJobsService.lambda$executeAsync$0(TestJobsService.java:38)
	at app//com.transferwise.common.baseutils.transactionsmanagement.TransactionsHelper$Builder.lambda$call$0(TransactionsHelper.java:111)
	at app//com.transferwise.common.baseutils.ExceptionUtils.doUnchecked(ExceptionUtils.java:14)
	at app//com.transferwise.common.baseutils.transactionsmanagement.TransactionsHelper$Builder.call(TransactionsHelper.java:96)
	at app//com.transferwise.tasks.impl.jobs.test.TestJobsService.executeAsync(TestJobsService.java:37)
	at app//com.transferwise.payout.processing.impl.kbank.KbankPayoutTransferProcessIntSpec.waitForConfirmationFile(KbankPayoutTransferProcessIntSpec.groovy:752)
	at com.transferwise.payout.processing.impl.kbank.KbankPayoutTransferProcessIntSpec.Kbank Scenario#4 = success Transfer then bounced when checking EOD confirmation file(KbankPayoutTransferProcessIntSpec.groovy:508)
Caused by: java.sql.SQLException: (conn=56) Lock wait timeout exceeded; try restarting transaction
	at org.mariadb.jdbc.export.ExceptionFactory.createException(ExceptionFactory.java:306)

```


## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
