### PR TITLE
CAA-2346: Fix metrics for cancelling tasks

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.50.0
+version=1.50.1
 org.gradle.internal.http.socketTimeout=120000

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/helpers/CoreMetricsTemplate.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/helpers/CoreMetricsTemplate.java
@@ -538,12 +538,12 @@ public class CoreMetricsTemplate implements ICoreMetricsTemplate {
   }
 
   public void registerTaskCancelled(String taskType) {
-    meterCache.counter(METRIC_TASKS_CANCELLED_COUNT, TagsSet.of(TAG_BUCKET_ID, resolveBucketId(null), TAG_TASK_TYPE, taskType))
+    meterCache.counter(METRIC_TASKS_CANCELLED_COUNT, TagsSet.of(TAG_TASK_TYPE, taskType))
         .increment();
   }
 
   public void registerTaskCancellationFailure(String taskType) {
-    meterCache.counter(METRIC_TASKS_FAILED_CANCELLATION_COUNT, TagsSet.of(TAG_BUCKET_ID, resolveBucketId(null), TAG_TASK_TYPE, taskType))
+    meterCache.counter(METRIC_TASKS_FAILED_CANCELLATION_COUNT, TagsSet.of(TAG_TASK_TYPE, taskType))
         .increment();
   }
 }


### PR DESCRIPTION
## Context

We populate bucket metrics as null always, this PR removes this tagSet for the metrics.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
