### PR TITLE
Allow customising task error logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.51.0 - 2025/04/17
+
+### Changed
+
+By default, when a task fails with a processing error, we log it with ERROR level and retry it according to the retry policy.
+Override `ITaskRetryPolicy#getExceptionHandler` method with custom exception handler to change the default behavior.
+For example, if you want to log it differently or log it only on last the retry.
+
 ## 1.50.0 - 2025/02/12
 
 ### Changed

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.50.1
+version=1.51.0
 org.gradle.internal.http.socketTimeout=120000

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/handler/ChainedTaskRetryPolicy.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/handler/ChainedTaskRetryPolicy.java
@@ -1,6 +1,7 @@
 package com.transferwise.tasks.handler;
 
 import com.transferwise.tasks.domain.ITask;
+import com.transferwise.tasks.handler.interfaces.ITaskExceptionHandler;
 import com.transferwise.tasks.handler.interfaces.ITaskRetryPolicy;
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -14,6 +15,7 @@ import lombok.experimental.Accessors;
 public class ChainedTaskRetryPolicy implements ITaskRetryPolicy {
 
   private List<ITaskRetryPolicy> retryPolicies;
+  private ITaskExceptionHandler exceptionHandler;
 
   @Override
   public ZonedDateTime getRetryTime(ITask task, Throwable t) {

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/handler/ExponentialTaskRetryPolicy.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/handler/ExponentialTaskRetryPolicy.java
@@ -3,6 +3,7 @@ package com.transferwise.tasks.handler;
 import com.google.common.math.LongMath;
 import com.transferwise.common.context.TwContextClockHolder;
 import com.transferwise.tasks.domain.ITask;
+import com.transferwise.tasks.handler.interfaces.ITaskExceptionHandler;
 import com.transferwise.tasks.handler.interfaces.ITaskRetryPolicy;
 import java.time.Duration;
 import java.time.ZonedDateTime;
@@ -27,6 +28,7 @@ public class ExponentialTaskRetryPolicy implements ITaskRetryPolicy {
   private Duration maxDelay = Duration.ofDays(1);
   private long maxCount = 1;
   private long triesDelta = 0;
+  private ITaskExceptionHandler exceptionHandler;
 
   @Override
   public ZonedDateTime getRetryTime(ITask taskForProcessing, Throwable t) {

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/handler/interfaces/ITaskExceptionHandler.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/handler/interfaces/ITaskExceptionHandler.java
@@ -1,0 +1,17 @@
+package com.transferwise.tasks.handler.interfaces;
+
+import com.transferwise.tasks.domain.ITask;
+import java.time.ZonedDateTime;
+
+@FunctionalInterface
+public interface ITaskExceptionHandler {
+
+  /**
+   * Handle the exception thrown during task processing.
+   *
+   * @param task      task
+   * @param t         thrown exception
+   * @param retryTime next retry time, {@code null} if no next retry
+   */
+  void handle(Throwable t, ITask task, ZonedDateTime retryTime);
+}

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/handler/interfaces/ITaskRetryPolicy.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/handler/interfaces/ITaskRetryPolicy.java
@@ -17,4 +17,15 @@ public interface ITaskRetryPolicy {
   default boolean resetTriesCountOnSuccess(IBaseTask task) {
     return false;
   }
+
+  /**
+   * By default, when a task fails with a processing error, we log it with ERROR level and retry it according to the retry policy. Override this
+   * method with custom exception handler to change the default behavior. For example, if you want to log it differently or log it only on the last
+   * retry.
+   *
+   * @return the custom exception handler or {@code null} if the default behavior should be used
+   */
+  default ITaskExceptionHandler getExceptionHandler() {
+    return null;
+  }
 }


### PR DESCRIPTION
## Context

By default, we log processing exceptions with ERROR logging level.
If you do not want to log a specific error, or if you want to log it yourself (for example, you want to log with INFO level instead or on last retry only), you can now override the behaviour using `ITaskRetryPolicy#logException` method.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
