### PR TITLE
Tweaking max triggers in memory defaults.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# 1.51.2 - 2025/08/15
+# 1.51.3 - 2025/09/19
+
+### Changed
+
+- Reducing default maxTriggersInMemory to 10_000, but leaving it the same for production environment.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Reducing default maxTriggersInMemory to 10_000, but leaving it the same for production environment.
+  It allows to reduce the reserve heap size in non-production environments.
 
 ### Changed
 

--- a/build.libraries.gradle
+++ b/build.libraries.gradle
@@ -10,6 +10,8 @@ ext {
             guava                           : "com.google.guava:guava:33.3.1-jre",
             jakartaValidationApi            : 'jakarta.validation:jakarta.validation-api:3.0.2',
             javaxValidationApi              : "javax.validation:validation-api:2.0.1.Final",
+            lubenZstd                       : 'com.github.luben:zstd-jni:1.5.6-7',
+            lz4Java                         : 'org.lz4:lz4-java:1.8.0',
             semver4j                        : "com.vdurmont:semver4j:3.1.0",
             spotbugsAnnotations             : "com.github.spotbugs:spotbugs-annotations:${spotbugs.toolVersion.get()}",
             springBootDependencies          : "org.springframework.boot:spring-boot-dependencies:$springBootVersion",
@@ -23,8 +25,7 @@ ext {
             twBaseUtils                     : "com.transferwise.common:tw-base-utils:1.13.0",
             twEntryPointsStarter            : 'com.transferwise.common:tw-entrypoints-starter:2.16.0',
             twSpyqlStarter                  : 'com.transferwise.common:tw-spyql-starter:1.6.2',
-            lubenZstd                       : 'com.github.luben:zstd-jni:1.5.6-7',
-            lz4Java                         : 'org.lz4:lz4-java:1.8.0',
+            wiseEnvironmentStarter          : "com.transferwise.common:wise-environment-starter:0.1.4",
 
             // versions managed by spring-boot-dependencies platform
             flywayCore                      : "org.flywaydb:flyway-core",

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-version=1.51.2
+version=1.51.3
 org.gradle.internal.http.socketTimeout=120000

--- a/tw-tasks-core-spring-boot-starter/build.gradle
+++ b/tw-tasks-core-spring-boot-starter/build.gradle
@@ -9,6 +9,7 @@ dependencies {
 
     implementation libraries.apacheCuratorRecipies
     implementation libraries.micrometerCore
+    implementation libraries.wiseEnvironmentStarter
 
     runtimeOnly libraries.twGracefulShutdown
     runtimeOnly libraries.twContextStarter

--- a/tw-tasks-core-spring-boot-starter/src/main/java/com/transferwise/tasks/core/autoconfigure/TwTasksEnvironmentPostProcessor.java
+++ b/tw-tasks-core-spring-boot-starter/src/main/java/com/transferwise/tasks/core/autoconfigure/TwTasksEnvironmentPostProcessor.java
@@ -1,6 +1,8 @@
 package com.transferwise.tasks.core.autoconfigure;
 
 import com.transferwise.tasks.helpers.CoreMetricsTemplate;
+import com.wise.common.environment.WiseEnvironment;
+import com.wise.common.environment.WiseProfile;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
@@ -34,6 +36,13 @@ public class TwTasksEnvironmentPostProcessor implements EnvironmentPostProcessor
 
       MapPropertySource mapPropertySource = new MapPropertySource(PROPERTY_SOURCE_KEY, map);
       environment.getPropertySources().addLast(mapPropertySource);
+
+      WiseEnvironment.setDefaultProperties(dsl -> dsl
+          .source("tw-tasks-executor")
+          .profile(WiseProfile.PRODUCTION)
+          .keyPrefix("tw-tasks.core.")
+          .set("max-triggers-in-memory", 100_000)
+      );
     }
   }
 }

--- a/tw-tasks-core/src/main/java/com/transferwise/tasks/TasksProperties.java
+++ b/tw-tasks-core/src/main/java/com/transferwise/tasks/TasksProperties.java
@@ -84,7 +84,7 @@ public class TasksProperties {
    */
   @Min(1L)
   @jakarta.validation.constraints.Min(1L)
-  private int maxTriggersInMemory = 100000;
+  private int maxTriggersInMemory = 10_000;
   /**
    * How many triggers maximum do we retrieve from Kafka with one polling loop.
    */


### PR DESCRIPTION
## Context

- Reducing default maxTriggersInMemory to 10_000, but leaving it the same for production environment.
  It allows to reduce the reserve heap size in non-production environments.

## Checklist
- [x] Change meets or does not compromise the [Baseline Security Requirements](https://transferwise.atlassian.net/wiki/spaces/EKB/pages/434929973/Baseline+Security+Requirements) 
